### PR TITLE
fix: make id to pass when multiple tools are passed

### DIFF
--- a/libs/ibm/langchain_ibm/chat_models.py
+++ b/libs/ibm/langchain_ibm/chat_models.py
@@ -742,14 +742,6 @@ class ChatWatsonx(BaseChatModel):
                 run_manager.on_llm_new_token(
                     generation_chunk.text, chunk=generation_chunk, logprobs=logprobs
                 )
-            if hasattr(generation_chunk.message, "tool_calls") and isinstance(
-                generation_chunk.message.tool_calls, list
-            ):
-                first_tool_call = (
-                    generation_chunk.message.tool_calls[0]
-                    if generation_chunk.message.tool_calls
-                    else None
-                )
 
             is_first_chunk = False
 

--- a/libs/ibm/langchain_ibm/chat_models.py
+++ b/libs/ibm/langchain_ibm/chat_models.py
@@ -721,7 +721,6 @@ class ChatWatsonx(BaseChatModel):
         default_chunk_class: Type[BaseMessageChunk] = AIMessageChunk
         base_generation_info: dict = {}
 
-        # TODO: ?
         is_first_chunk = True
 
         for chunk in self.watsonx_model.chat_stream(

--- a/libs/ibm/tests/integration_tests/test_chat_models.py
+++ b/libs/ibm/tests/integration_tests/test_chat_models.py
@@ -429,7 +429,7 @@ def test_22b_bind_tools_tool_choice_as_dict() -> None:
 
     with_tool = chat.bind_tools([Person], tool_choice=tool_choice)
 
-    result = with_tool.invoke("Erick, 27 years old")
+    result = with_tool.invoke("Erick, 27 years old. Make sure to use correct name")
     assert isinstance(result, AIMessage)
     assert result.content == ""  # should just be tool call
     tool_call = result.tool_calls[0]
@@ -726,6 +726,7 @@ def test_structured_output() -> None:
         model_id=MODEL_ID_TOOL,
         url=URL,  # type: ignore[arg-type]
         project_id=WX_PROJECT_ID,
+        temperature=0,
     )
     schema = {
         "title": "AnswerWithJustification",
@@ -950,7 +951,7 @@ def test_invoke_with_params_5() -> None:
 
 
 def test_init_and_invoke_with_params_1() -> None:
-    params_1 = None
+    params_1 = {"max_tokens": 11}
     chat = ChatWatsonx(
         model_id=MODEL_ID_TOOL,
         url=URL,  # type: ignore[arg-type]
@@ -961,7 +962,7 @@ def test_init_and_invoke_with_params_1() -> None:
     completion_tokens = resp.response_metadata.get("token_usage", {}).get(
         "completion_tokens"
     )
-    assert chat.params == {}
+    assert chat.params == params_1
     assert 7 < completion_tokens < 11
 
 

--- a/libs/ibm/tests/integration_tests/test_llms.py
+++ b/libs/ibm/tests/integration_tests/test_llms.py
@@ -233,14 +233,14 @@ def test_watsonxllm_stream() -> None:
 
     linked_text_stream = ""
     for chunk in stream_response:
-        assert isinstance(chunk, str), (
-            f"chunk expect type '{str}', actual '{type(chunk)}'"
-        )
+        assert isinstance(
+            chunk, str
+        ), f"chunk expect type '{str}', actual '{type(chunk)}'"
         linked_text_stream += chunk
     print(f"Linked text stream: {linked_text_stream}")
-    assert response == linked_text_stream, (
-        "Linked text stream are not the same as generated text"
-    )
+    assert (
+        response == linked_text_stream
+    ), "Linked text stream are not the same as generated text"
 
 
 def test_watsonxllm_stream_with_kwargs() -> None:
@@ -252,9 +252,9 @@ def test_watsonxllm_stream_with_kwargs() -> None:
     stream_response = watsonxllm.stream("What color sunflower is?", raw_response=True)
 
     for chunk in stream_response:
-        assert isinstance(chunk, str), (
-            f"chunk expect type '{str}', actual '{type(chunk)}'"
-        )
+        assert isinstance(
+            chunk, str
+        ), f"chunk expect type '{str}', actual '{type(chunk)}'"
 
 
 def test_watsonxllm_stream_with_params() -> None:
@@ -276,14 +276,14 @@ def test_watsonxllm_stream_with_params() -> None:
 
     linked_text_stream = ""
     for chunk in stream_response:
-        assert isinstance(chunk, str), (
-            f"chunk expect type '{str}', actual '{type(chunk)}'"
-        )
+        assert isinstance(
+            chunk, str
+        ), f"chunk expect type '{str}', actual '{type(chunk)}'"
         linked_text_stream += chunk
     print(f"Linked text stream: {linked_text_stream}")
-    assert response == linked_text_stream, (
-        "Linked text stream are not the same as generated text"
-    )
+    assert (
+        response == linked_text_stream
+    ), "Linked text stream are not the same as generated text"
 
 
 def test_watsonxllm_stream_with_params_2() -> None:
@@ -300,9 +300,9 @@ def test_watsonxllm_stream_with_params_2() -> None:
     stream_response = watsonxllm.stream("What color sunflower is?", params=parameters)
 
     for chunk in stream_response:
-        assert isinstance(chunk, str), (
-            f"chunk expect type '{str}', actual '{type(chunk)}'"
-        )
+        assert isinstance(
+            chunk, str
+        ), f"chunk expect type '{str}', actual '{type(chunk)}'"
         print(chunk)
 
 
@@ -323,9 +323,9 @@ def test_watsonxllm_stream_with_params_3() -> None:
     stream_response = watsonxllm.stream("What color sunflower is?", params=parameters_2)
 
     for chunk in stream_response:
-        assert isinstance(chunk, str), (
-            f"chunk expect type '{str}', actual '{type(chunk)}'"
-        )
+        assert isinstance(
+            chunk, str
+        ), f"chunk expect type '{str}', actual '{type(chunk)}'"
         print(chunk)
 
 
@@ -346,9 +346,9 @@ def test_watsonxllm_stream_with_params_4() -> None:
     stream_response = watsonxllm.stream("What color sunflower is?", **parameters_2)  # type: ignore[arg-type]
 
     for chunk in stream_response:
-        assert isinstance(chunk, str), (
-            f"chunk expect type '{str}', actual '{type(chunk)}'"
-        )
+        assert isinstance(
+            chunk, str
+        ), f"chunk expect type '{str}', actual '{type(chunk)}'"
         print(chunk)
 
 

--- a/libs/ibm/tests/integration_tests/test_llms.py
+++ b/libs/ibm/tests/integration_tests/test_llms.py
@@ -233,14 +233,14 @@ def test_watsonxllm_stream() -> None:
 
     linked_text_stream = ""
     for chunk in stream_response:
-        assert isinstance(
-            chunk, str
-        ), f"chunk expect type '{str}', actual '{type(chunk)}'"
+        assert isinstance(chunk, str), (
+            f"chunk expect type '{str}', actual '{type(chunk)}'"
+        )
         linked_text_stream += chunk
     print(f"Linked text stream: {linked_text_stream}")
-    assert (
-        response == linked_text_stream
-    ), "Linked text stream are not the same as generated text"
+    assert response == linked_text_stream, (
+        "Linked text stream are not the same as generated text"
+    )
 
 
 def test_watsonxllm_stream_with_kwargs() -> None:
@@ -252,9 +252,9 @@ def test_watsonxllm_stream_with_kwargs() -> None:
     stream_response = watsonxllm.stream("What color sunflower is?", raw_response=True)
 
     for chunk in stream_response:
-        assert isinstance(
-            chunk, str
-        ), f"chunk expect type '{str}', actual '{type(chunk)}'"
+        assert isinstance(chunk, str), (
+            f"chunk expect type '{str}', actual '{type(chunk)}'"
+        )
 
 
 def test_watsonxllm_stream_with_params() -> None:
@@ -276,14 +276,14 @@ def test_watsonxllm_stream_with_params() -> None:
 
     linked_text_stream = ""
     for chunk in stream_response:
-        assert isinstance(
-            chunk, str
-        ), f"chunk expect type '{str}', actual '{type(chunk)}'"
+        assert isinstance(chunk, str), (
+            f"chunk expect type '{str}', actual '{type(chunk)}'"
+        )
         linked_text_stream += chunk
     print(f"Linked text stream: {linked_text_stream}")
-    assert (
-        response == linked_text_stream
-    ), "Linked text stream are not the same as generated text"
+    assert response == linked_text_stream, (
+        "Linked text stream are not the same as generated text"
+    )
 
 
 def test_watsonxllm_stream_with_params_2() -> None:
@@ -300,9 +300,9 @@ def test_watsonxllm_stream_with_params_2() -> None:
     stream_response = watsonxllm.stream("What color sunflower is?", params=parameters)
 
     for chunk in stream_response:
-        assert isinstance(
-            chunk, str
-        ), f"chunk expect type '{str}', actual '{type(chunk)}'"
+        assert isinstance(chunk, str), (
+            f"chunk expect type '{str}', actual '{type(chunk)}'"
+        )
         print(chunk)
 
 
@@ -323,9 +323,9 @@ def test_watsonxllm_stream_with_params_3() -> None:
     stream_response = watsonxllm.stream("What color sunflower is?", params=parameters_2)
 
     for chunk in stream_response:
-        assert isinstance(
-            chunk, str
-        ), f"chunk expect type '{str}', actual '{type(chunk)}'"
+        assert isinstance(chunk, str), (
+            f"chunk expect type '{str}', actual '{type(chunk)}'"
+        )
         print(chunk)
 
 
@@ -346,9 +346,9 @@ def test_watsonxllm_stream_with_params_4() -> None:
     stream_response = watsonxllm.stream("What color sunflower is?", **parameters_2)  # type: ignore[arg-type]
 
     for chunk in stream_response:
-        assert isinstance(
-            chunk, str
-        ), f"chunk expect type '{str}', actual '{type(chunk)}'"
+        assert isinstance(chunk, str), (
+            f"chunk expect type '{str}', actual '{type(chunk)}'"
+        )
         print(chunk)
 
 


### PR DESCRIPTION
Fix for #48 

Based on the watsonx.ai Chat API docs https://cloud.ibm.com/apidocs/watsonx-ai#text-chat , the tool_call `id` is always included in the response - the case when model decides to use tools. Also, when model return multiple tools, the proper ` id` will be returned for each tool_call.

Unit tests:
![Screenshot 2025-01-31 at 14 21 25](https://github.com/user-attachments/assets/271b1779-1124-47e9-af05-11c2c9208dd7)

Integrations tests:
![Screenshot 2025-01-31 at 14 20 57](https://github.com/user-attachments/assets/020db381-e894-4f61-a127-2ac0e5d216c5)

Please note, that the erros not related to the introduced changes.
