### PR TITLE
fix: usage chat stream

### DIFF
--- a/libs/ibm/langchain_ibm/chat_models.py
+++ b/libs/ibm/langchain_ibm/chat_models.py
@@ -331,7 +331,7 @@ def _convert_chunk_to_generation_chunk(
     choices = chunk.get("choices", [])
 
     usage_metadata: Optional[UsageMetadata] = (
-        _create_usage_metadata(token_usage) if token_usage else None
+        _create_usage_metadata(token_usage) if token_usage and not choices else None
     )
 
     if len(choices) == 0:

--- a/libs/ibm/langchain_ibm/chat_models.py
+++ b/libs/ibm/langchain_ibm/chat_models.py
@@ -741,7 +741,10 @@ class ChatWatsonx(BaseChatModel):
             if generation_chunk is None:
                 continue
 
-            if generation_chunk.message.usage_metadata:
+            if (
+                hasattr(generation_chunk.message, "usage_metadata")
+                and generation_chunk.message.usage_metadata
+            ):
                 _prompt_tokens_included = True
             default_chunk_class = generation_chunk.message.__class__
             logprobs = (generation_chunk.generation_info or {}).get("logprobs")
@@ -815,7 +818,7 @@ class ChatWatsonx(BaseChatModel):
             message = _convert_dict_to_message(res["message"], response["id"])
 
             if token_usage and isinstance(message, AIMessage):
-                message.usage_metadata = _create_usage_metadata(token_usage)
+                message.usage_metadata = _create_usage_metadata(token_usage, False)
             generation_info = generation_info or {}
             generation_info["finish_reason"] = (
                 res.get("finish_reason")

--- a/libs/ibm/pyproject.toml
+++ b/libs/ibm/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langchain-ibm"
-version = "0.3.5"
+version = "0.3.6"
 description = "An integration package connecting IBM watsonx.ai and LangChain"
 authors = ["IBM"]
 readme = "README.md"

--- a/libs/ibm/tests/integration_tests/test_chat_models.py
+++ b/libs/ibm/tests/integration_tests/test_chat_models.py
@@ -667,7 +667,7 @@ def test_streaming_multiple_tool_call() -> None:
         if ai_message is None:
             ai_message = chunk
         else:
-            ai_message += chunk
+            ai_message += chunk  # type: ignore[assignment]
         print(chunk.id, type(chunk.id))
         assert isinstance(chunk, AIMessageChunk)
         assert chunk.content == ""


### PR DESCRIPTION
Starting from version `1.2.7` `ibm-watsonx-ai` returns usage metadata in the last chunk of chat stream.