### PR TITLE
feat: Improve `WatsonxToolkit` and `WatsonxTool`

### DIFF
--- a/libs/ibm/langchain_ibm/toolkit.py
+++ b/libs/ibm/langchain_ibm/toolkit.py
@@ -166,9 +166,9 @@ class WatsonxToolkit(BaseToolkit):
             config = {
                 "maxResults": 3,
             }
+            google_search.set_config(config)
             input = {
                 "input": "Search IBM",
-                "config": config,
             }
             search_result = google_search.invoke(input=input)
 

--- a/libs/ibm/langchain_ibm/toolkit.py
+++ b/libs/ibm/langchain_ibm/toolkit.py
@@ -11,10 +11,10 @@ from typing import (
 )
 
 from ibm_watsonx_ai import APIClient, Credentials  # type: ignore
-from ibm_watsonx_ai.foundation_models.utils import (
+from ibm_watsonx_ai.foundation_models.utils import (  # type: ignore
     Tool,
     Toolkit,
-)  # type: ignore
+)
 from langchain_core.callbacks import CallbackManagerForToolRun
 from langchain_core.tools.base import BaseTool, BaseToolkit
 from langchain_core.utils.utils import secret_from_env
@@ -31,7 +31,7 @@ from typing_extensions import Self
 from langchain_ibm.utils import check_for_attribute, convert_to_ibm_watsonx_tool
 
 
-def json_schema_to_pydantic_model(name: str, schema: Dict[str, Any]) -> BaseModel:
+def json_schema_to_pydantic_model(name: str, schema: Dict[str, Any]) -> Type[BaseModel]:
     properties = schema.get("properties", {})
     fields = {}
 
@@ -51,7 +51,7 @@ def json_schema_to_pydantic_model(name: str, schema: Dict[str, Any]) -> BaseMode
 
         fields[field_name] = (py_type, ... if is_required else None)
 
-    return create_model(name, **fields)
+    return create_model(name, **fields)  # type: ignore[call-overload]
 
 
 class WatsonxTool(BaseTool):
@@ -102,9 +102,9 @@ class WatsonxTool(BaseTool):
 
     def _run(
         self,
-        *args,
+        *args: Any,
         run_manager: Optional[CallbackManagerForToolRun] = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> dict:
         """Run the tool."""
         if self.tool_input_schema is None:
@@ -118,7 +118,7 @@ class WatsonxTool(BaseTool):
 
         return self.watsonx_tool.run(input, self.config)
 
-    def set_config(self, config: dict):
+    def set_config(self, config: dict) -> None:
         """Set config properties.
 
         Example:

--- a/libs/ibm/langchain_ibm/toolkit.py
+++ b/libs/ibm/langchain_ibm/toolkit.py
@@ -2,12 +2,12 @@
 
 import urllib.parse
 from typing import (
+    Any,
     Dict,
     List,
     Optional,
     Type,
     Union,
-    Any,
 )
 
 from ibm_watsonx_ai import APIClient, Credentials  # type: ignore
@@ -18,7 +18,14 @@ from ibm_watsonx_ai.foundation_models.utils import (
 from langchain_core.callbacks import CallbackManagerForToolRun
 from langchain_core.tools.base import BaseTool, BaseToolkit
 from langchain_core.utils.utils import secret_from_env
-from pydantic import BaseModel, ConfigDict, Field, SecretStr, model_validator, create_model
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    SecretStr,
+    create_model,
+    model_validator,
+)
 from typing_extensions import Self
 
 from langchain_ibm.utils import check_for_attribute, convert_to_ibm_watsonx_tool
@@ -38,7 +45,7 @@ def json_schema_to_pydantic_model(name: str, schema: Dict[str, Any]) -> BaseMode
             "number": float,
             "boolean": bool,
             "array": list,
-            "object": dict
+            "object": dict,
         }
         py_type = type_mapping.get(field_type, Any)
 
@@ -87,7 +94,9 @@ class WatsonxTool(BaseTool):
         )
         converted_tool = convert_to_ibm_watsonx_tool(self.watsonx_tool)
         json_schema = converted_tool["function"]["parameters"]
-        self.args_schema = json_schema_to_pydantic_model(name="ToolArgsSchema", schema=json_schema)
+        self.args_schema = json_schema_to_pydantic_model(
+            name="ToolArgsSchema", schema=json_schema
+        )
 
         return self
 
@@ -102,7 +111,9 @@ class WatsonxTool(BaseTool):
             input = kwargs.get("input") or args[0]
         else:
             input = {
-                k: v for k, v in kwargs.items() if k in self.tool_input_schema["properties"]
+                k: v
+                for k, v in kwargs.items()
+                if k in self.tool_input_schema["properties"]
             }
 
         return self.watsonx_tool.run(input, self.config)

--- a/libs/ibm/langchain_ibm/toolkit.py
+++ b/libs/ibm/langchain_ibm/toolkit.py
@@ -181,7 +181,7 @@ class WatsonxToolkit(BaseToolkit):
         * True - default path to truststore will be taken
         * False - no verification will be made"""
 
-    tools: List[WatsonxTool] = []
+    tools: Optional[List[WatsonxTool]] = None
     """Tools in the toolkit."""
 
     watsonx_toolkit: Optional[Toolkit] = Field(
@@ -246,7 +246,7 @@ class WatsonxToolkit(BaseToolkit):
 
     def get_tools(self) -> list[WatsonxTool]:  # type: ignore
         """Get the tools in the toolkit."""
-        return self.tools
+        return self.tools  # type: ignore[return-value]
 
     def get_tool(self, tool_name: str) -> WatsonxTool:
         """Get the tool with a given name."""

--- a/libs/ibm/langchain_ibm/utils.py
+++ b/libs/ibm/langchain_ibm/utils.py
@@ -59,8 +59,8 @@ def check_duplicate_chat_params(params: dict, kwargs: dict) -> None:
             f"{list(duplicate_keys)}"
         )
 
-def convert_to_ibm_watsonx_tool(utility_tool: Tool) -> dict:
 
+def convert_to_ibm_watsonx_tool(utility_tool: Tool) -> dict:
     def parse_parameters(input_schema: dict | None) -> dict:
         if input_schema:
             parameters = deepcopy(input_schema)
@@ -83,9 +83,7 @@ def convert_to_ibm_watsonx_tool(utility_tool: Tool) -> dict:
         "function": {
             "name": utility_tool.name,
             "description": utility_tool.description,
-            "parameters": parse_parameters(
-                utility_tool.input_schema
-            ),
+            "parameters": parse_parameters(utility_tool.input_schema),
         },
     }
     return tool

--- a/libs/ibm/langchain_ibm/utils.py
+++ b/libs/ibm/langchain_ibm/utils.py
@@ -1,8 +1,11 @@
 from copy import deepcopy
-from typing import Any, Dict, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 from ibm_watsonx_ai.foundation_models.schema import BaseSchema  # type: ignore
 from pydantic import SecretStr
+
+if TYPE_CHECKING:
+    from langchain_ibm.toolkit import WatsonxTool
 
 
 def check_for_attribute(value: SecretStr | None, key: str, env_key: str) -> None:
@@ -57,3 +60,78 @@ def check_duplicate_chat_params(params: dict, kwargs: dict) -> None:
             f"Duplicate parameters found in params and keyword arguments: "
             f"{list(duplicate_keys)}"
         )
+
+
+def convert_to_watsonx_tool(tool: "WatsonxTool") -> dict:
+    """Convert `WatsonxTool` to watsonx tool structure.
+
+    Args:
+        tool: `WatsonxTool` from `WatsonxToolkit`
+
+
+    Example:
+
+    .. code-block:: python
+
+        from langchain_ibm import WatsonxToolkit
+
+        watsonx_toolkit = WatsonxToolkit(
+            url="https://us-south.ml.cloud.ibm.com",
+            apikey="*****",
+        )
+        weather_tool = watsonx_toolkit.get_tool("Weather")
+        convert_to_watsonx_tool(weather_tool)
+
+        # Return
+        # {
+        #     "type": "function",
+        #     "function": {
+        #         "name": "Weather",
+        #         "description": "Find the weather for a city.",
+        #         "parameters": {
+        #             "type": "object",
+        #             "properties": {
+        #                 "location": {
+        #                     "title": "location",
+        #                     "description": "Name of the location",
+        #                     "type": "string",
+        #                 },
+        #                 "country": {
+        #                     "title": "country",
+        #                     "description": "Name of the state or country",
+        #                     "type": "string",
+        #                 },
+        #             },
+        #             "required": ["location"],
+        #         },
+        #     },
+        # }
+
+    """
+
+    def parse_parameters(input_schema: dict | None) -> dict:
+        if input_schema:
+            parameters = deepcopy(input_schema)
+        else:
+            parameters = {
+                "type": "object",
+                "properties": {
+                    "input": {
+                        "description": "Input to be used when running tool.",
+                        "type": "string",
+                    },
+                },
+                "required": ["input"],
+            }
+
+        return parameters
+
+    watsonx_tool = {
+        "type": "function",
+        "function": {
+            "name": tool.name,
+            "description": tool.description,
+            "parameters": parse_parameters(tool.tool_input_schema),
+        },
+    }
+    return watsonx_tool

--- a/libs/ibm/langchain_ibm/utils.py
+++ b/libs/ibm/langchain_ibm/utils.py
@@ -2,7 +2,6 @@ from copy import deepcopy
 from typing import Any, Dict, Optional, Union
 
 from ibm_watsonx_ai.foundation_models.schema import BaseSchema  # type: ignore
-from ibm_watsonx_ai.foundation_models.utils import Tool  # type: ignore
 from pydantic import SecretStr
 
 
@@ -58,32 +57,3 @@ def check_duplicate_chat_params(params: dict, kwargs: dict) -> None:
             f"Duplicate parameters found in params and keyword arguments: "
             f"{list(duplicate_keys)}"
         )
-
-
-def convert_to_watsonx_tool(utility_tool: Tool) -> dict:
-    def parse_parameters(input_schema: dict | None) -> dict:
-        if input_schema:
-            parameters = deepcopy(input_schema)
-        else:
-            parameters = {
-                "type": "object",
-                "properties": {
-                    "input": {
-                        "description": "Input to be used when running tool.",
-                        "type": "string",
-                    },
-                },
-                "required": ["input"],
-            }
-
-        return parameters
-
-    tool = {
-        "type": "function",
-        "function": {
-            "name": utility_tool.name,
-            "description": utility_tool.description,
-            "parameters": parse_parameters(utility_tool.input_schema),
-        },
-    }
-    return tool

--- a/libs/ibm/langchain_ibm/utils.py
+++ b/libs/ibm/langchain_ibm/utils.py
@@ -2,6 +2,7 @@ from copy import deepcopy
 from typing import Any, Dict, Optional, Union
 
 from ibm_watsonx_ai.foundation_models.schema import BaseSchema  # type: ignore
+from ibm_watsonx_ai.foundation_models.utils import Tool  # type: ignore
 from pydantic import SecretStr
 
 
@@ -57,3 +58,34 @@ def check_duplicate_chat_params(params: dict, kwargs: dict) -> None:
             f"Duplicate parameters found in params and keyword arguments: "
             f"{list(duplicate_keys)}"
         )
+
+def convert_to_ibm_watsonx_tool(utility_tool: Tool) -> dict:
+
+    def parse_parameters(input_schema: dict | None) -> dict:
+        if input_schema:
+            parameters = deepcopy(input_schema)
+        else:
+            parameters = {
+                "type": "object",
+                "properties": {
+                    "input": {
+                        "description": "Input to be used when running tool.",
+                        "type": "string",
+                    },
+                },
+                "required": ["input"],
+            }
+
+        return parameters
+
+    tool = {
+        "type": "function",
+        "function": {
+            "name": utility_tool.name,
+            "description": utility_tool.description,
+            "parameters": parse_parameters(
+                utility_tool.input_schema
+            ),
+        },
+    }
+    return tool

--- a/libs/ibm/langchain_ibm/utils.py
+++ b/libs/ibm/langchain_ibm/utils.py
@@ -60,7 +60,7 @@ def check_duplicate_chat_params(params: dict, kwargs: dict) -> None:
         )
 
 
-def convert_to_ibm_watsonx_tool(utility_tool: Tool) -> dict:
+def convert_to_watsonx_tool(utility_tool: Tool) -> dict:
     def parse_parameters(input_schema: dict | None) -> dict:
         if input_schema:
             parameters = deepcopy(input_schema)

--- a/libs/ibm/tests/integration_tests/test_chat_models.py
+++ b/libs/ibm/tests/integration_tests/test_chat_models.py
@@ -22,7 +22,7 @@ from langchain_ibm import ChatWatsonx, WatsonxToolkit
 WX_APIKEY = os.environ.get("WATSONX_APIKEY", "")
 WX_PROJECT_ID = os.environ.get("WATSONX_PROJECT_ID", "")
 
-URL = "https://yp-qa.ml.cloud.ibm.com" # "https://us-south.ml.cloud.ibm.com"
+URL = "https://us-south.ml.cloud.ibm.com"
 
 MODEL_ID = "ibm/granite-34b-code-instruct"
 MODEL_ID_TOOL = "mistralai/mistral-large"
@@ -527,6 +527,7 @@ def test_23_bind_tools_list_tool_choice_auto() -> None:
     assert resp.content
     assert len(resp.tool_calls) == 0  # type: ignore
 
+
 def test_24a_bind_watsonx_tools() -> None:
     chat = ChatWatsonx(
         model_id=MODEL_ID_TOOL,
@@ -538,9 +539,7 @@ def test_24a_bind_watsonx_tools() -> None:
     )
     weather_tool = toolkit.get_tool("Weather")
 
-    tools = [
-        weather_tool
-    ]
+    tools = [weather_tool]
 
     llm_with_tools = chat.bind_tools(tools=tools)
 
@@ -554,6 +553,7 @@ def test_24a_bind_watsonx_tools() -> None:
     assert isinstance(tool_call["args"], dict)
     assert "location" in tool_call["args"]
 
+
 def test_24b_bind_watsonx_tools_tool_choice_auto() -> None:
     chat = ChatWatsonx(
         model_id=MODEL_ID_TOOL,
@@ -566,9 +566,7 @@ def test_24b_bind_watsonx_tools_tool_choice_auto() -> None:
     )
     weather_tool = toolkit.get_tool("Weather")
 
-    tools = [
-        weather_tool
-    ]
+    tools = [weather_tool]
 
     llm_with_tools = chat.bind_tools(tools=tools, tool_choice="auto")
 
@@ -581,6 +579,7 @@ def test_24b_bind_watsonx_tools_tool_choice_auto() -> None:
     assert tool_call["name"] == "Weather"
     assert isinstance(tool_call["args"], dict)
     assert "location" in tool_call["args"]
+
 
 def test_25a_bind_watsonx_tools_tool_choice_as_dict() -> None:
     """Test that tool choice is respected just passing in True."""
@@ -596,9 +595,7 @@ def test_25a_bind_watsonx_tools_tool_choice_as_dict() -> None:
     )
     weather_tool = toolkit.get_tool("Weather")
 
-    tools = [
-        weather_tool
-    ]
+    tools = [weather_tool]
 
     tool_choice = {"type": "function", "function": {"name": "Weather"}}
 
@@ -612,6 +609,7 @@ def test_25a_bind_watsonx_tools_tool_choice_as_dict() -> None:
     assert tool_call["args"] == {
         "location": "Boston",
     }
+
 
 def test_26a_bind_watsonx_tools_list_tool_choice_auto() -> None:
     """Test that tool choice is respected just passing in True."""

--- a/libs/ibm/tests/integration_tests/test_chat_models.py
+++ b/libs/ibm/tests/integration_tests/test_chat_models.py
@@ -535,7 +535,7 @@ def test_24a_bind_watsonx_tools() -> None:
         project_id=WX_PROJECT_ID,
     )
     toolkit = WatsonxToolkit(
-        url=URL,
+        url=URL,  # type: ignore[arg-type]
     )
     weather_tool = toolkit.get_tool("Weather")
 
@@ -562,7 +562,7 @@ def test_24b_bind_watsonx_tools_tool_choice_auto() -> None:
     )
 
     toolkit = WatsonxToolkit(
-        url=URL,
+        url=URL,  # type: ignore[arg-type]
     )
     weather_tool = toolkit.get_tool("Weather")
 
@@ -591,7 +591,7 @@ def test_25a_bind_watsonx_tools_tool_choice_as_dict() -> None:
     )
 
     toolkit = WatsonxToolkit(
-        url=URL,
+        url=URL,  # type: ignore[arg-type]
     )
     weather_tool = toolkit.get_tool("Weather")
 
@@ -621,7 +621,7 @@ def test_26a_bind_watsonx_tools_list_tool_choice_auto() -> None:
     )
 
     toolkit = WatsonxToolkit(
-        url=URL,
+        url=URL,  # type: ignore[arg-type]
     )
     weather_tool = toolkit.get_tool("Weather")
     google_search_tool = toolkit.get_tool("GoogleSearch")
@@ -659,7 +659,7 @@ def test_26b_bind_watsonx_tools_list_tool_choice_dict() -> None:
     )
 
     toolkit = WatsonxToolkit(
-        url=URL,
+        url=URL,  # type: ignore[arg-type]
     )
     weather_tool = toolkit.get_tool("Weather")
     google_search_tool = toolkit.get_tool("GoogleSearch")

--- a/libs/ibm/tests/integration_tests/test_toolkit.py
+++ b/libs/ibm/tests/integration_tests/test_toolkit.py
@@ -10,7 +10,7 @@ from langchain_ibm import WatsonxToolkit
 
 WX_APIKEY = os.environ.get("WATSONX_APIKEY", "")
 
-URL = "https://yp-qa.ml.cloud.ibm.com" # "https://us-south.ml.cloud.ibm.com"
+URL = "https://us-south.ml.cloud.ibm.com"
 
 TOOL_NAME_1 = "GoogleSearch"
 TOOL_NAME_2 = "Weather"

--- a/libs/ibm/tests/integration_tests/test_toolkit.py
+++ b/libs/ibm/tests/integration_tests/test_toolkit.py
@@ -53,7 +53,7 @@ def test_04_invoke_tool_with_config_schema() -> None:
     config = {
         "maxResults": 3,
     }
-    tool.set_config(config)
+    tool.set_tool_config(config)
 
     tool_input = {
         "input": "Search IBM",

--- a/libs/ibm/tests/integration_tests/test_toolkit.py
+++ b/libs/ibm/tests/integration_tests/test_toolkit.py
@@ -1,6 +1,6 @@
 """Test WatsonxToolkit.
 
-You'll need to set WATSONX_APIKEY and WATSONX_PROJECT_ID environment variables.
+You'll need to set WATSONX_APIKEY environment variable.
 """
 
 import json
@@ -9,9 +9,8 @@ import os
 from langchain_ibm import WatsonxToolkit
 
 WX_APIKEY = os.environ.get("WATSONX_APIKEY", "")
-WX_PROJECT_ID = os.environ.get("WATSONX_PROJECT_ID", "")
 
-URL = "https://us-south.ml.cloud.ibm.com"
+URL = "https://yp-qa.ml.cloud.ibm.com" # "https://us-south.ml.cloud.ibm.com"
 
 TOOL_NAME_1 = "GoogleSearch"
 TOOL_NAME_2 = "Weather"
@@ -20,7 +19,6 @@ TOOL_NAME_2 = "Weather"
 def test_01_get_tools() -> None:
     watsonx_toolkit = WatsonxToolkit(
         url=URL,  # type: ignore[arg-type]
-        project_id=WX_PROJECT_ID,
     )
     tools = watsonx_toolkit.get_tools()
     assert tools
@@ -29,7 +27,6 @@ def test_01_get_tools() -> None:
 def test_02_get_tool_with_config_schema() -> None:
     watsonx_toolkit = WatsonxToolkit(
         url=URL,  # type: ignore[arg-type]
-        project_id=WX_PROJECT_ID,
     )
     tool = watsonx_toolkit.get_tool(tool_name=TOOL_NAME_1)
     assert tool.name == TOOL_NAME_1
@@ -40,7 +37,6 @@ def test_02_get_tool_with_config_schema() -> None:
 def test_03_get_tool_with_input_schema() -> None:
     watsonx_toolkit = WatsonxToolkit(
         url=URL,  # type: ignore[arg-type]
-        project_id=WX_PROJECT_ID,
     )
     tool = watsonx_toolkit.get_tool(tool_name=TOOL_NAME_2)
     assert tool.name == TOOL_NAME_2
@@ -51,18 +47,16 @@ def test_03_get_tool_with_input_schema() -> None:
 def test_04_invoke_tool_with_config_schema() -> None:
     watsonx_toolkit = WatsonxToolkit(
         url=URL,  # type: ignore[arg-type]
-        project_id=WX_PROJECT_ID,
     )
     tool = watsonx_toolkit.get_tool(tool_name=TOOL_NAME_1)
-    assert tool.name == TOOL_NAME_1
-    assert tool.tool_config_schema
 
     config = {
         "maxResults": 3,
     }
+    tool.set_config(config)
+
     tool_input = {
         "input": "Search IBM",
-        "config": config,
     }
 
     result = tool.invoke(tool_input)
@@ -79,21 +73,32 @@ def test_04_invoke_tool_with_config_schema() -> None:
 def test_05_invoke_tool_with_input_schema() -> None:
     watsonx_toolkit = WatsonxToolkit(
         url=URL,  # type: ignore[arg-type]
-        project_id=WX_PROJECT_ID,
     )
     tool = watsonx_toolkit.get_tool(tool_name=TOOL_NAME_2)
-    assert tool.name == TOOL_NAME_2
-    assert tool.tool_input_schema
 
     tool_input = {
-        "input": {
-            "name": "New York",
-        },
+        "location": "New York",
     }
 
     result = tool.invoke(tool_input)
     output = result.get("output")
 
     assert output
-    assert tool_input["input"]["name"] in output
+    assert tool_input["location"] in output
     assert "temperature" in output.lower()
+
+
+def test_06_invoke_tool_with_simple_input() -> None:
+    watsonx_toolkit = WatsonxToolkit(
+        url=URL,  # type: ignore[arg-type]
+    )
+    tool = watsonx_toolkit.get_tool(tool_name=TOOL_NAME_1)
+
+    result = tool.invoke("Search IBM")
+    output = json.loads(result.get("output"))
+
+    assert isinstance(output, list)
+    for answer in output:
+        assert answer.get("title")
+        assert answer.get("description")
+        assert answer.get("url")

--- a/libs/ibm/tests/integration_tests/test_tools_standard.py
+++ b/libs/ibm/tests/integration_tests/test_tools_standard.py
@@ -56,7 +56,4 @@ class TestWatsonxToolsStandard(ToolsIntegrationTests):
         """
         return {
             "input": "Search IBM",
-            "config": {
-                "maxResults": 3,
-            },
         }

--- a/libs/ibm/tests/unit_tests/test_chat_models.py
+++ b/libs/ibm/tests/unit_tests/test_chat_models.py
@@ -89,7 +89,7 @@ def test_initialize_chat_watsonx_with_all_supported_params(mocker: Any) -> None:
     # All params values are taken from
     # ibm_watsonx_ai.foundation_models.schema.TextChatParameters.get_sample_params()
 
-    from ibm_watsonx_ai.foundation_models.schema import (  # type: ignore[import-not-found]
+    from ibm_watsonx_ai.foundation_models.schema import (  # type: ignore[import-not-found, import-untyped]
         TextChatParameters,
     )
 

--- a/libs/ibm/tests/unit_tests/test_chat_models.py
+++ b/libs/ibm/tests/unit_tests/test_chat_models.py
@@ -89,7 +89,7 @@ def test_initialize_chat_watsonx_with_all_supported_params(mocker: Any) -> None:
     # All params values are taken from
     # ibm_watsonx_ai.foundation_models.schema.TextChatParameters.get_sample_params()
 
-    from ibm_watsonx_ai.foundation_models.schema import (  # type: ignore[import-untyped]
+    from ibm_watsonx_ai.foundation_models.schema import (  # type: ignore[import-not-found]
         TextChatParameters,
     )
 

--- a/libs/ibm/tests/unit_tests/test_chat_models_standard.py
+++ b/libs/ibm/tests/unit_tests/test_chat_models_standard.py
@@ -17,6 +17,7 @@ client.service_instance._credentials = credentials
 client.default_space_id = None
 client.default_project_id = None
 client._httpx_client = None
+client._async_httpx_client = None
 
 
 class TestWatsonxStandard(ChatModelUnitTests):

--- a/libs/ibm/tests/unit_tests/test_tools_standard.py
+++ b/libs/ibm/tests/unit_tests/test_tools_standard.py
@@ -54,7 +54,4 @@ class TestWatsonxToolsStandard(ToolsUnitTests):
         """
         return {
             "input": "Search IBM",
-            "config": {
-                "maxResults": 3,
-            },
         }


### PR DESCRIPTION
**Description:**

- Dynamic creation of `args_schema` for each tool, including only `input_schema` properties in it. Config properties have to be set using `set_tool_config()`.
- Updated `_run()` implementation to fit into unique `args_schema` for each tool. 
- Get all tools when initialize `WatsonxToolkit` and save in `tools` attribute.
- Updated tests.