### PR TITLE
fix: Added more tolerant validation for embeddings type

### DIFF
--- a/libs/langchain-db2/langchain_db2/db2vs.py
+++ b/libs/langchain-db2/langchain_db2/db2vs.py
@@ -35,6 +35,8 @@ from langchain_core.documents import Document
 from langchain_core.embeddings import Embeddings
 from langchain_core.vectorstores import VectorStore
 
+from langchain_db2.utils import EmbeddingsSchema
+
 logger = logging.getLogger(__name__)
 log_level = os.getenv("LOG_LEVEL", "ERROR").upper()
 logging.basicConfig(
@@ -201,7 +203,7 @@ class DB2VS(VectorStore):
             """Initialize with ibm_db_dbi client."""
             self.client = client
             """Initialize with necessary components."""
-            if not isinstance(embedding_function, Embeddings):
+            if not isinstance(embedding_function, EmbeddingsSchema):
                 logger.warning(
                     "`embedding_function` is expected to be an Embeddings "
                     "object, support for passing in a function will soon "
@@ -243,7 +245,7 @@ class DB2VS(VectorStore):
         """
         return (
             self.embedding_function
-            if isinstance(self.embedding_function, Embeddings)
+            if isinstance(self.embedding_function, EmbeddingsSchema)
             else None
         )
 
@@ -257,7 +259,7 @@ class DB2VS(VectorStore):
         return len(embedded_document[0])
 
     def _embed_documents(self, texts: List[str]) -> List[List[float]]:
-        if isinstance(self.embedding_function, Embeddings):
+        if isinstance(self.embedding_function, EmbeddingsSchema):
             return self.embedding_function.embed_documents(texts)
         elif callable(self.embedding_function):
             return [self.embedding_function(text) for text in texts]
@@ -267,7 +269,7 @@ class DB2VS(VectorStore):
             )
 
     def _embed_query(self, text: str) -> List[float]:
-        if isinstance(self.embedding_function, Embeddings):
+        if isinstance(self.embedding_function, EmbeddingsSchema):
             return self.embedding_function.embed_query(text)
         else:
             return self.embedding_function(text)
@@ -387,7 +389,7 @@ class DB2VS(VectorStore):
         Return:
             List[Document]: documents most similar to a query
         """
-        if isinstance(self.embedding_function, Embeddings):
+        if isinstance(self.embedding_function, EmbeddingsSchema):
             embedding = self.embedding_function.embed_query(query)
         documents = self.similarity_search_by_vector(
             embedding=embedding, k=k, filter=filter, **kwargs
@@ -414,7 +416,7 @@ class DB2VS(VectorStore):
         **kwargs: Any,
     ) -> List[Tuple[Document, float]]:
         """Return docs most similar to query."""
-        if isinstance(self.embedding_function, Embeddings):
+        if isinstance(self.embedding_function, EmbeddingsSchema):
             embedding = self.embedding_function.embed_query(query)
         docs_and_scores = self.similarity_search_by_vector_with_relevance_scores(
             embedding=embedding, k=k, filter=filter, **kwargs

--- a/libs/langchain-db2/langchain_db2/utils.py
+++ b/libs/langchain-db2/langchain_db2/utils.py
@@ -1,0 +1,7 @@
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class EmbeddingsSchema(Protocol):
+    def embed_documents(self, texts: list[str]) -> list[list[float]]: ...
+    def embed_query(self, text: str) -> list[float]: ...


### PR DESCRIPTION
## Description
Added more tolerant validation for embeddings type

Rather than verifying that `embedding_function` is an instance of LangChain’s Embedding class, we will accept any `embedding_function` provided it adheres to the defined interface.

## Tests

Integration tests using `WatsonxEmbeddings` (LangChain object) object as an `embedding_function`

<img width="518" alt="Screenshot 2025-06-30 at 11 34 42" src="https://github.com/user-attachments/assets/3de4fe2b-71ed-4740-8c94-e84aeb70e3a3" />

Integration tests using `Embeddings` (from ibm_watsonx_ai.foundation_models.embeddings import Embeddings) object as an `embedding_function`

<img width="516" alt="Screenshot 2025-06-30 at 11 41 32" src="https://github.com/user-attachments/assets/9cd1fb27-f81a-4db9-bb2f-3259a913c09d" />
