### PR TITLE
[langchain-ibm/feat]: Added support for Model Gateway (Embeddings), Added async methods

### DIFF
--- a/libs/ibm/langchain_ibm/chat_models.py
+++ b/libs/ibm/langchain_ibm/chat_models.py
@@ -430,7 +430,16 @@ class ChatWatsonx(BaseChatModel):
     """Type of model to use."""
 
     model: Optional[str] = None
-    """Name of model for given provider or alias."""
+    """
+    Name or alias of the foundation model to use.  
+    When using IBM’s watsonx.ai Model Gateway (public preview), you can specify any 
+    supported third-party model—OpenAI, Anthropic, NVIDIA, Cerebras, or IBM’s own 
+    Granite series—via a single, OpenAI-compatible interface. Models must be explicitly 
+    provisioned (opt-in) through the Gateway to ensure secure, vendor-agnostic access 
+    and easy switch-over without reconfiguration.
+
+    For more details on configuration and usage, see IBM watsonx Model Gateway docs: https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-model-gateway.html?context=wx&audience=wdp
+    """
 
     deployment_id: Optional[str] = None
     """Type of deployed model to use."""

--- a/libs/ibm/langchain_ibm/embeddings.py
+++ b/libs/ibm/langchain_ibm/embeddings.py
@@ -21,7 +21,16 @@ class WatsonxEmbeddings(BaseModel, LangChainEmbeddings):
     """Type of model to use."""
 
     model: Optional[str] = None
-    """Name of model for given provider or alias."""
+    """
+    Name or alias of the foundation model to use.  
+    When using IBM’s watsonx.ai Model Gateway (public preview), you can specify any 
+    supported third-party model—OpenAI, Anthropic, NVIDIA, Cerebras, or IBM’s own 
+    Granite series—via a single, OpenAI-compatible interface. Models must be explicitly 
+    provisioned (opt-in) through the Gateway to ensure secure, vendor-agnostic access 
+    and easy switch-over without reconfiguration.
+    
+    For more details on configuration and usage, see IBM watsonx Model Gateway docs: https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-model-gateway.html?context=wx&audience=wdp
+    """
 
     project_id: Optional[str] = None
     """ID of the Watson Studio project."""
@@ -74,7 +83,8 @@ class WatsonxEmbeddings(BaseModel, LangChainEmbeddings):
         * the path to a CA_BUNDLE file
         * the path of directory with certificates of trusted CAs
         * True - default path to truststore will be taken
-        * False - no verification will be made"""
+        * False - no verification will be made
+    """
 
     watsonx_embed: Embeddings = Field(default=None)  #: :meta private:
 

--- a/libs/ibm/langchain_ibm/embeddings.py
+++ b/libs/ibm/langchain_ibm/embeddings.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List, Optional, Union
 
 from ibm_watsonx_ai import APIClient, Credentials  # type: ignore
 from ibm_watsonx_ai.foundation_models.embeddings import Embeddings  # type: ignore
+from ibm_watsonx_ai.gateway import Gateway  # type: ignore
 from langchain_core.embeddings import Embeddings as LangChainEmbeddings
 from langchain_core.utils.utils import secret_from_env
 from pydantic import BaseModel, ConfigDict, Field, SecretStr, model_validator
@@ -18,6 +19,9 @@ class WatsonxEmbeddings(BaseModel, LangChainEmbeddings):
 
     model_id: Optional[str] = None
     """Type of model to use."""
+
+    model: Optional[str] = None
+    """Name of model for given provider or alias."""
 
     project_id: Optional[str] = None
     """ID of the Watson Studio project."""
@@ -74,6 +78,10 @@ class WatsonxEmbeddings(BaseModel, LangChainEmbeddings):
 
     watsonx_embed: Embeddings = Field(default=None)  #: :meta private:
 
+    watsonx_embed_gateway: Gateway = Field(
+        default=None, exclude=True
+    )  #: :meta private:
+
     watsonx_client: Optional[APIClient] = Field(default=None)  #: :meta private:
 
     model_config = ConfigDict(
@@ -85,6 +93,12 @@ class WatsonxEmbeddings(BaseModel, LangChainEmbeddings):
     @model_validator(mode="after")
     def validate_environment(self) -> Self:
         """Validate that credentials and python package exists in environment."""
+        if self.watsonx_embed_gateway is not None:
+            raise NotImplementedError(
+                "Passing the 'watsonx_embed_gateway' parameter to the "
+                "WatsonxEmbeddings constructor is not supported yet."
+            )
+
         if isinstance(self.watsonx_embed, Embeddings):
             self.model_id = getattr(self.watsonx_embed, "model_id")
             self.project_id = getattr(
@@ -98,17 +112,36 @@ class WatsonxEmbeddings(BaseModel, LangChainEmbeddings):
             self.params = getattr(self.watsonx_embed, "params")
 
         elif isinstance(self.watsonx_client, APIClient):
-            watsonx_embed = Embeddings(
-                model_id=self.model_id,
-                params=self.params,
-                api_client=self.watsonx_client,
-                project_id=self.project_id,
-                space_id=self.space_id,
-                verify=self.verify,
-            )
-            self.watsonx_embed = watsonx_embed
+            if sum(map(bool, (self.model, self.model_id))) != 1:
+                raise ValueError(
+                    "The parameters 'model' and 'model_id' are mutually exclusive. "
+                    "Please specify exactly one of these parameters when "
+                    "initializing WatsonxEmbeddings."
+                )
+            if self.model is not None:
+                watsonx_embed_gateway = Gateway(
+                    api_client=self.watsonx_client,
+                    verify=self.verify,
+                )
+                self.watsonx_embed_gateway = watsonx_embed_gateway
+            else:
+                watsonx_embed = Embeddings(
+                    model_id=self.model_id,
+                    params=self.params,
+                    api_client=self.watsonx_client,
+                    project_id=self.project_id,
+                    space_id=self.space_id,
+                    verify=self.verify,
+                )
+                self.watsonx_embed = watsonx_embed
 
         else:
+            if sum(map(bool, (self.model, self.model_id))) != 1:
+                raise ValueError(
+                    "The parameters 'model' and 'model_id' are mutually exclusive. "
+                    "Please specify exactly one of these parameters when "
+                    "initializing WatsonxEmbeddings."
+                )
             check_for_attribute(self.url, "url", "WATSONX_URL")
 
             if "cloud.ibm.com" in self.url.get_secret_value():
@@ -157,26 +190,59 @@ class WatsonxEmbeddings(BaseModel, LangChainEmbeddings):
                 version=self.version.get_secret_value() if self.version else None,
                 verify=self.verify,
             )
+            if self.model is not None:
+                watsonx_embed_gateway = Gateway(
+                    credentials=credentials,
+                    verify=self.verify,
+                )
+                self.watsonx_embed_gateway = watsonx_embed_gateway
 
-            watsonx_embed = Embeddings(
-                model_id=self.model_id,
-                params=self.params,
-                credentials=credentials,
-                project_id=self.project_id,
-                space_id=self.space_id,
-            )
+            else:
+                watsonx_embed = Embeddings(
+                    model_id=self.model_id,
+                    params=self.params,
+                    credentials=credentials,
+                    project_id=self.project_id,
+                    space_id=self.space_id,
+                )
 
-            self.watsonx_embed = watsonx_embed
+                self.watsonx_embed = watsonx_embed
 
         return self
 
     def embed_documents(self, texts: List[str], **kwargs: Any) -> List[List[float]]:
         """Embed search docs."""
         params = extract_params(kwargs, self.params)
-        return self.watsonx_embed.embed_documents(
-            texts=texts, **(kwargs | {"params": params})
-        )
+        if self.watsonx_embed_gateway is not None:
+            embed_response = self.watsonx_embed_gateway.embeddings.create(
+                model=self.model, input=texts, **(kwargs | params)
+            )
+            return [embedding["embedding"] for embedding in embed_response["data"]]
+        else:
+            return self.watsonx_embed.embed_documents(
+                texts=texts, **(kwargs | {"params": params})
+            )
+
+    async def aembed_documents(
+        self, texts: List[str], **kwargs: Any
+    ) -> List[List[float]]:
+        """Asynchronous Embed search docs."""
+        params = extract_params(kwargs, self.params)
+        if self.watsonx_embed_gateway is not None:
+            embed_response = await self.watsonx_embed_gateway.embeddings.acreate(
+                model=self.model, input=texts, **(kwargs | params)
+            )
+            return [embedding["embedding"] for embedding in embed_response["data"]]
+        else:
+            return await self.watsonx_embed.aembed_documents(
+                texts=texts, **(kwargs | {"params": params})
+            )
 
     def embed_query(self, text: str, **kwargs: Any) -> List[float]:
         """Embed query text."""
         return self.embed_documents([text], **kwargs)[0]
+
+    async def aembed_query(self, text: str, **kwargs: Any) -> List[float]:
+        """Asynchronous Embed query text."""
+        embeddings = await self.aembed_documents([text], **kwargs)
+        return embeddings[0]

--- a/libs/ibm/langchain_ibm/utils.py
+++ b/libs/ibm/langchain_ibm/utils.py
@@ -151,7 +151,10 @@ def gateway_error_handler(func: Callable) -> Callable:
         try:
             return func(self, *args, **kwargs)
         except ApiRequestFailure:
-            if getattr(self, "watsonx_model_gateway", None) is not None:
+            if any(
+                hasattr(self, attr)
+                for attr in ("watsonx_model_gateway", "watsonx_embed_gateway")
+            ):
                 logger.warning(
                     "You are calling the Model Gateway endpoint using the 'model' "
                     "parameter. Please ensure this model is registered with the "

--- a/libs/ibm/poetry.lock
+++ b/libs/ibm/poetry.lock
@@ -275,79 +275,79 @@ files = [
 
 [[package]]
 name = "coverage"
-version = "7.9.1"
+version = "7.9.2"
 description = "Code coverage measurement for Python"
 optional = false
 python-versions = ">=3.9"
 groups = ["test"]
 files = [
-    {file = "coverage-7.9.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:cc94d7c5e8423920787c33d811c0be67b7be83c705f001f7180c7b186dcf10ca"},
-    {file = "coverage-7.9.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:16aa0830d0c08a2c40c264cef801db8bc4fc0e1892782e45bcacbd5889270509"},
-    {file = "coverage-7.9.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf95981b126f23db63e9dbe4cf65bd71f9a6305696fa5e2262693bc4e2183f5b"},
-    {file = "coverage-7.9.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f05031cf21699785cd47cb7485f67df619e7bcdae38e0fde40d23d3d0210d3c3"},
-    {file = "coverage-7.9.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb4fbcab8764dc072cb651a4bcda4d11fb5658a1d8d68842a862a6610bd8cfa3"},
-    {file = "coverage-7.9.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:0f16649a7330ec307942ed27d06ee7e7a38417144620bb3d6e9a18ded8a2d3e5"},
-    {file = "coverage-7.9.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:cea0a27a89e6432705fffc178064503508e3c0184b4f061700e771a09de58187"},
-    {file = "coverage-7.9.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e980b53a959fa53b6f05343afbd1e6f44a23ed6c23c4b4c56c6662bbb40c82ce"},
-    {file = "coverage-7.9.1-cp310-cp310-win32.whl", hash = "sha256:70760b4c5560be6ca70d11f8988ee6542b003f982b32f83d5ac0b72476607b70"},
-    {file = "coverage-7.9.1-cp310-cp310-win_amd64.whl", hash = "sha256:a66e8f628b71f78c0e0342003d53b53101ba4e00ea8dabb799d9dba0abbbcebe"},
-    {file = "coverage-7.9.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:95c765060e65c692da2d2f51a9499c5e9f5cf5453aeaf1420e3fc847cc060582"},
-    {file = "coverage-7.9.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ba383dc6afd5ec5b7a0d0c23d38895db0e15bcba7fb0fa8901f245267ac30d86"},
-    {file = "coverage-7.9.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:37ae0383f13cbdcf1e5e7014489b0d71cc0106458878ccde52e8a12ced4298ed"},
-    {file = "coverage-7.9.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:69aa417a030bf11ec46149636314c24c8d60fadb12fc0ee8f10fda0d918c879d"},
-    {file = "coverage-7.9.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0a4be2a28656afe279b34d4f91c3e26eccf2f85500d4a4ff0b1f8b54bf807338"},
-    {file = "coverage-7.9.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:382e7ddd5289f140259b610e5f5c58f713d025cb2f66d0eb17e68d0a94278875"},
-    {file = "coverage-7.9.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e5532482344186c543c37bfad0ee6069e8ae4fc38d073b8bc836fc8f03c9e250"},
-    {file = "coverage-7.9.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a39d18b3f50cc121d0ce3838d32d58bd1d15dab89c910358ebefc3665712256c"},
-    {file = "coverage-7.9.1-cp311-cp311-win32.whl", hash = "sha256:dd24bd8d77c98557880def750782df77ab2b6885a18483dc8588792247174b32"},
-    {file = "coverage-7.9.1-cp311-cp311-win_amd64.whl", hash = "sha256:6b55ad10a35a21b8015eabddc9ba31eb590f54adc9cd39bcf09ff5349fd52125"},
-    {file = "coverage-7.9.1-cp311-cp311-win_arm64.whl", hash = "sha256:6ad935f0016be24c0e97fc8c40c465f9c4b85cbbe6eac48934c0dc4d2568321e"},
-    {file = "coverage-7.9.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a8de12b4b87c20de895f10567639c0797b621b22897b0af3ce4b4e204a743626"},
-    {file = "coverage-7.9.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5add197315a054e92cee1b5f686a2bcba60c4c3e66ee3de77ace6c867bdee7cb"},
-    {file = "coverage-7.9.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:600a1d4106fe66f41e5d0136dfbc68fe7200a5cbe85610ddf094f8f22e1b0300"},
-    {file = "coverage-7.9.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2a876e4c3e5a2a1715a6608906aa5a2e0475b9c0f68343c2ada98110512ab1d8"},
-    {file = "coverage-7.9.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:81f34346dd63010453922c8e628a52ea2d2ccd73cb2487f7700ac531b247c8a5"},
-    {file = "coverage-7.9.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:888f8eee13f2377ce86d44f338968eedec3291876b0b8a7289247ba52cb984cd"},
-    {file = "coverage-7.9.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:9969ef1e69b8c8e1e70d591f91bbc37fc9a3621e447525d1602801a24ceda898"},
-    {file = "coverage-7.9.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:60c458224331ee3f1a5b472773e4a085cc27a86a0b48205409d364272d67140d"},
-    {file = "coverage-7.9.1-cp312-cp312-win32.whl", hash = "sha256:5f646a99a8c2b3ff4c6a6e081f78fad0dde275cd59f8f49dc4eab2e394332e74"},
-    {file = "coverage-7.9.1-cp312-cp312-win_amd64.whl", hash = "sha256:30f445f85c353090b83e552dcbbdad3ec84c7967e108c3ae54556ca69955563e"},
-    {file = "coverage-7.9.1-cp312-cp312-win_arm64.whl", hash = "sha256:af41da5dca398d3474129c58cb2b106a5d93bbb196be0d307ac82311ca234342"},
-    {file = "coverage-7.9.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:31324f18d5969feef7344a932c32428a2d1a3e50b15a6404e97cba1cc9b2c631"},
-    {file = "coverage-7.9.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0c804506d624e8a20fb3108764c52e0eef664e29d21692afa375e0dd98dc384f"},
-    {file = "coverage-7.9.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ef64c27bc40189f36fcc50c3fb8f16ccda73b6a0b80d9bd6e6ce4cffcd810bbd"},
-    {file = "coverage-7.9.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d4fe2348cc6ec372e25adec0219ee2334a68d2f5222e0cba9c0d613394e12d86"},
-    {file = "coverage-7.9.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:34ed2186fe52fcc24d4561041979a0dec69adae7bce2ae8d1c49eace13e55c43"},
-    {file = "coverage-7.9.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:25308bd3d00d5eedd5ae7d4357161f4df743e3c0240fa773ee1b0f75e6c7c0f1"},
-    {file = "coverage-7.9.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:73e9439310f65d55a5a1e0564b48e34f5369bee943d72c88378f2d576f5a5751"},
-    {file = "coverage-7.9.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:37ab6be0859141b53aa89412a82454b482c81cf750de4f29223d52268a86de67"},
-    {file = "coverage-7.9.1-cp313-cp313-win32.whl", hash = "sha256:64bdd969456e2d02a8b08aa047a92d269c7ac1f47e0c977675d550c9a0863643"},
-    {file = "coverage-7.9.1-cp313-cp313-win_amd64.whl", hash = "sha256:be9e3f68ca9edb897c2184ad0eee815c635565dbe7a0e7e814dc1f7cbab92c0a"},
-    {file = "coverage-7.9.1-cp313-cp313-win_arm64.whl", hash = "sha256:1c503289ffef1d5105d91bbb4d62cbe4b14bec4d13ca225f9c73cde9bb46207d"},
-    {file = "coverage-7.9.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0b3496922cb5f4215bf5caaef4cf12364a26b0be82e9ed6d050f3352cf2d7ef0"},
-    {file = "coverage-7.9.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:9565c3ab1c93310569ec0d86b017f128f027cab0b622b7af288696d7ed43a16d"},
-    {file = "coverage-7.9.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2241ad5dbf79ae1d9c08fe52b36d03ca122fb9ac6bca0f34439e99f8327ac89f"},
-    {file = "coverage-7.9.1-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3bb5838701ca68b10ebc0937dbd0eb81974bac54447c55cd58dea5bca8451029"},
-    {file = "coverage-7.9.1-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b30a25f814591a8c0c5372c11ac8967f669b97444c47fd794926e175c4047ece"},
-    {file = "coverage-7.9.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:2d04b16a6062516df97969f1ae7efd0de9c31eb6ebdceaa0d213b21c0ca1a683"},
-    {file = "coverage-7.9.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:7931b9e249edefb07cd6ae10c702788546341d5fe44db5b6108a25da4dca513f"},
-    {file = "coverage-7.9.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:52e92b01041151bf607ee858e5a56c62d4b70f4dac85b8c8cb7fb8a351ab2c10"},
-    {file = "coverage-7.9.1-cp313-cp313t-win32.whl", hash = "sha256:684e2110ed84fd1ca5f40e89aa44adf1729dc85444004111aa01866507adf363"},
-    {file = "coverage-7.9.1-cp313-cp313t-win_amd64.whl", hash = "sha256:437c576979e4db840539674e68c84b3cda82bc824dd138d56bead1435f1cb5d7"},
-    {file = "coverage-7.9.1-cp313-cp313t-win_arm64.whl", hash = "sha256:18a0912944d70aaf5f399e350445738a1a20b50fbea788f640751c2ed9208b6c"},
-    {file = "coverage-7.9.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6f424507f57878e424d9a95dc4ead3fbdd72fd201e404e861e465f28ea469951"},
-    {file = "coverage-7.9.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:535fde4001b2783ac80865d90e7cc7798b6b126f4cd8a8c54acfe76804e54e58"},
-    {file = "coverage-7.9.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:02532fd3290bb8fa6bec876520842428e2a6ed6c27014eca81b031c2d30e3f71"},
-    {file = "coverage-7.9.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:56f5eb308b17bca3bbff810f55ee26d51926d9f89ba92707ee41d3c061257e55"},
-    {file = "coverage-7.9.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bfa447506c1a52271f1b0de3f42ea0fa14676052549095e378d5bff1c505ff7b"},
-    {file = "coverage-7.9.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:9ca8e220006966b4a7b68e8984a6aee645a0384b0769e829ba60281fe61ec4f7"},
-    {file = "coverage-7.9.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:49f1d0788ba5b7ba65933f3a18864117c6506619f5ca80326b478f72acf3f385"},
-    {file = "coverage-7.9.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:68cd53aec6f45b8e4724c0950ce86eacb775c6be01ce6e3669fe4f3a21e768ed"},
-    {file = "coverage-7.9.1-cp39-cp39-win32.whl", hash = "sha256:95335095b6c7b1cc14c3f3f17d5452ce677e8490d101698562b2ffcacc304c8d"},
-    {file = "coverage-7.9.1-cp39-cp39-win_amd64.whl", hash = "sha256:e1b5191d1648acc439b24721caab2fd0c86679d8549ed2c84d5a7ec1bedcc244"},
-    {file = "coverage-7.9.1-pp39.pp310.pp311-none-any.whl", hash = "sha256:db0f04118d1db74db6c9e1cb1898532c7dcc220f1d2718f058601f7c3f499514"},
-    {file = "coverage-7.9.1-py3-none-any.whl", hash = "sha256:66b974b145aa189516b6bf2d8423e888b742517d37872f6ee4c5be0073bd9a3c"},
-    {file = "coverage-7.9.1.tar.gz", hash = "sha256:6cf43c78c4282708a28e466316935ec7489a9c487518a77fa68f716c67909cec"},
+    {file = "coverage-7.9.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:66283a192a14a3854b2e7f3418d7db05cdf411012ab7ff5db98ff3b181e1f912"},
+    {file = "coverage-7.9.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4e01d138540ef34fcf35c1aa24d06c3de2a4cffa349e29a10056544f35cca15f"},
+    {file = "coverage-7.9.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f22627c1fe2745ee98d3ab87679ca73a97e75ca75eb5faee48660d060875465f"},
+    {file = "coverage-7.9.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4b1c2d8363247b46bd51f393f86c94096e64a1cf6906803fa8d5a9d03784bdbf"},
+    {file = "coverage-7.9.2-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c10c882b114faf82dbd33e876d0cbd5e1d1ebc0d2a74ceef642c6152f3f4d547"},
+    {file = "coverage-7.9.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:de3c0378bdf7066c3988d66cd5232d161e933b87103b014ab1b0b4676098fa45"},
+    {file = "coverage-7.9.2-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:1e2f097eae0e5991e7623958a24ced3282676c93c013dde41399ff63e230fcf2"},
+    {file = "coverage-7.9.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:28dc1f67e83a14e7079b6cea4d314bc8b24d1aed42d3582ff89c0295f09b181e"},
+    {file = "coverage-7.9.2-cp310-cp310-win32.whl", hash = "sha256:bf7d773da6af9e10dbddacbf4e5cab13d06d0ed93561d44dae0188a42c65be7e"},
+    {file = "coverage-7.9.2-cp310-cp310-win_amd64.whl", hash = "sha256:0c0378ba787681ab1897f7c89b415bd56b0b2d9a47e5a3d8dc0ea55aac118d6c"},
+    {file = "coverage-7.9.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a7a56a2964a9687b6aba5b5ced6971af308ef6f79a91043c05dd4ee3ebc3e9ba"},
+    {file = "coverage-7.9.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:123d589f32c11d9be7fe2e66d823a236fe759b0096f5db3fb1b75b2fa414a4fa"},
+    {file = "coverage-7.9.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:333b2e0ca576a7dbd66e85ab402e35c03b0b22f525eed82681c4b866e2e2653a"},
+    {file = "coverage-7.9.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:326802760da234baf9f2f85a39e4a4b5861b94f6c8d95251f699e4f73b1835dc"},
+    {file = "coverage-7.9.2-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:19e7be4cfec248df38ce40968c95d3952fbffd57b400d4b9bb580f28179556d2"},
+    {file = "coverage-7.9.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0b4a4cb73b9f2b891c1788711408ef9707666501ba23684387277ededab1097c"},
+    {file = "coverage-7.9.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:2c8937fa16c8c9fbbd9f118588756e7bcdc7e16a470766a9aef912dd3f117dbd"},
+    {file = "coverage-7.9.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:42da2280c4d30c57a9b578bafd1d4494fa6c056d4c419d9689e66d775539be74"},
+    {file = "coverage-7.9.2-cp311-cp311-win32.whl", hash = "sha256:14fa8d3da147f5fdf9d298cacc18791818f3f1a9f542c8958b80c228320e90c6"},
+    {file = "coverage-7.9.2-cp311-cp311-win_amd64.whl", hash = "sha256:549cab4892fc82004f9739963163fd3aac7a7b0df430669b75b86d293d2df2a7"},
+    {file = "coverage-7.9.2-cp311-cp311-win_arm64.whl", hash = "sha256:c2667a2b913e307f06aa4e5677f01a9746cd08e4b35e14ebcde6420a9ebb4c62"},
+    {file = "coverage-7.9.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ae9eb07f1cfacd9cfe8eaee6f4ff4b8a289a668c39c165cd0c8548484920ffc0"},
+    {file = "coverage-7.9.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:9ce85551f9a1119f02adc46d3014b5ee3f765deac166acf20dbb851ceb79b6f3"},
+    {file = "coverage-7.9.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f8f6389ac977c5fb322e0e38885fbbf901743f79d47f50db706e7644dcdcb6e1"},
+    {file = "coverage-7.9.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ff0d9eae8cdfcd58fe7893b88993723583a6ce4dfbfd9f29e001922544f95615"},
+    {file = "coverage-7.9.2-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fae939811e14e53ed8a9818dad51d434a41ee09df9305663735f2e2d2d7d959b"},
+    {file = "coverage-7.9.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:31991156251ec202c798501e0a42bbdf2169dcb0f137b1f5c0f4267f3fc68ef9"},
+    {file = "coverage-7.9.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:d0d67963f9cbfc7c7f96d4ac74ed60ecbebd2ea6eeb51887af0f8dce205e545f"},
+    {file = "coverage-7.9.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:49b752a2858b10580969ec6af6f090a9a440a64a301ac1528d7ca5f7ed497f4d"},
+    {file = "coverage-7.9.2-cp312-cp312-win32.whl", hash = "sha256:88d7598b8ee130f32f8a43198ee02edd16d7f77692fa056cb779616bbea1b355"},
+    {file = "coverage-7.9.2-cp312-cp312-win_amd64.whl", hash = "sha256:9dfb070f830739ee49d7c83e4941cc767e503e4394fdecb3b54bfdac1d7662c0"},
+    {file = "coverage-7.9.2-cp312-cp312-win_arm64.whl", hash = "sha256:4e2c058aef613e79df00e86b6d42a641c877211384ce5bd07585ed7ba71ab31b"},
+    {file = "coverage-7.9.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:985abe7f242e0d7bba228ab01070fde1d6c8fa12f142e43debe9ed1dde686038"},
+    {file = "coverage-7.9.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:82c3939264a76d44fde7f213924021ed31f55ef28111a19649fec90c0f109e6d"},
+    {file = "coverage-7.9.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ae5d563e970dbe04382f736ec214ef48103d1b875967c89d83c6e3f21706d5b3"},
+    {file = "coverage-7.9.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bdd612e59baed2a93c8843c9a7cb902260f181370f1d772f4842987535071d14"},
+    {file = "coverage-7.9.2-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:256ea87cb2a1ed992bcdfc349d8042dcea1b80436f4ddf6e246d6bee4b5d73b6"},
+    {file = "coverage-7.9.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f44ae036b63c8ea432f610534a2668b0c3aee810e7037ab9d8ff6883de480f5b"},
+    {file = "coverage-7.9.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:82d76ad87c932935417a19b10cfe7abb15fd3f923cfe47dbdaa74ef4e503752d"},
+    {file = "coverage-7.9.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:619317bb86de4193debc712b9e59d5cffd91dc1d178627ab2a77b9870deb2868"},
+    {file = "coverage-7.9.2-cp313-cp313-win32.whl", hash = "sha256:0a07757de9feb1dfafd16ab651e0f628fd7ce551604d1bf23e47e1ddca93f08a"},
+    {file = "coverage-7.9.2-cp313-cp313-win_amd64.whl", hash = "sha256:115db3d1f4d3f35f5bb021e270edd85011934ff97c8797216b62f461dd69374b"},
+    {file = "coverage-7.9.2-cp313-cp313-win_arm64.whl", hash = "sha256:48f82f889c80af8b2a7bb6e158d95a3fbec6a3453a1004d04e4f3b5945a02694"},
+    {file = "coverage-7.9.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:55a28954545f9d2f96870b40f6c3386a59ba8ed50caf2d949676dac3ecab99f5"},
+    {file = "coverage-7.9.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:cdef6504637731a63c133bb2e6f0f0214e2748495ec15fe42d1e219d1b133f0b"},
+    {file = "coverage-7.9.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bcd5ebe66c7a97273d5d2ddd4ad0ed2e706b39630ed4b53e713d360626c3dbb3"},
+    {file = "coverage-7.9.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9303aed20872d7a3c9cb39c5d2b9bdbe44e3a9a1aecb52920f7e7495410dfab8"},
+    {file = "coverage-7.9.2-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc18ea9e417a04d1920a9a76fe9ebd2f43ca505b81994598482f938d5c315f46"},
+    {file = "coverage-7.9.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6406cff19880aaaadc932152242523e892faff224da29e241ce2fca329866584"},
+    {file = "coverage-7.9.2-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:2d0d4f6ecdf37fcc19c88fec3e2277d5dee740fb51ffdd69b9579b8c31e4232e"},
+    {file = "coverage-7.9.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c33624f50cf8de418ab2b4d6ca9eda96dc45b2c4231336bac91454520e8d1fac"},
+    {file = "coverage-7.9.2-cp313-cp313t-win32.whl", hash = "sha256:1df6b76e737c6a92210eebcb2390af59a141f9e9430210595251fbaf02d46926"},
+    {file = "coverage-7.9.2-cp313-cp313t-win_amd64.whl", hash = "sha256:f5fd54310b92741ebe00d9c0d1d7b2b27463952c022da6d47c175d246a98d1bd"},
+    {file = "coverage-7.9.2-cp313-cp313t-win_arm64.whl", hash = "sha256:c48c2375287108c887ee87d13b4070a381c6537d30e8487b24ec721bf2a781cb"},
+    {file = "coverage-7.9.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:ddc39510ac922a5c4c27849b739f875d3e1d9e590d1e7b64c98dadf037a16cce"},
+    {file = "coverage-7.9.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a535c0c7364acd55229749c2b3e5eebf141865de3a8f697076a3291985f02d30"},
+    {file = "coverage-7.9.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:df0f9ef28e0f20c767ccdccfc5ae5f83a6f4a2fbdfbcbcc8487a8a78771168c8"},
+    {file = "coverage-7.9.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2f3da12e0ccbcb348969221d29441ac714bbddc4d74e13923d3d5a7a0bebef7a"},
+    {file = "coverage-7.9.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0a17eaf46f56ae0f870f14a3cbc2e4632fe3771eab7f687eda1ee59b73d09fe4"},
+    {file = "coverage-7.9.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:669135a9d25df55d1ed56a11bf555f37c922cf08d80799d4f65d77d7d6123fcf"},
+    {file = "coverage-7.9.2-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:9d3a700304d01a627df9db4322dc082a0ce1e8fc74ac238e2af39ced4c083193"},
+    {file = "coverage-7.9.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:71ae8b53855644a0b1579d4041304ddc9995c7b21c8a1f16753c4d8903b4dfed"},
+    {file = "coverage-7.9.2-cp39-cp39-win32.whl", hash = "sha256:dd7a57b33b5cf27acb491e890720af45db05589a80c1ffc798462a765be6d4d7"},
+    {file = "coverage-7.9.2-cp39-cp39-win_amd64.whl", hash = "sha256:f65bb452e579d5540c8b37ec105dd54d8b9307b07bcaa186818c104ffda22441"},
+    {file = "coverage-7.9.2-pp39.pp310.pp311-none-any.whl", hash = "sha256:8a1166db2fb62473285bcb092f586e081e92656c7dfa8e9f62b4d39d7e6b5050"},
+    {file = "coverage-7.9.2-py3-none-any.whl", hash = "sha256:e425cd5b00f6fc0ed7cdbd766c70be8baab4b7839e4d4fe5fac48581dd968ea4"},
+    {file = "coverage-7.9.2.tar.gz", hash = "sha256:997024fa51e3290264ffd7492ec97d0690293ccd2b45a6cd7d82d945a4a80c8b"},
 ]
 
 [package.dependencies]
@@ -596,14 +596,14 @@ files = [
 
 [[package]]
 name = "langchain-core"
-version = "0.3.67"
+version = "0.3.68"
 description = "Building applications with LLMs through composability"
 optional = false
 python-versions = ">=3.9"
 groups = ["main", "test"]
 files = [
-    {file = "langchain_core-0.3.67-py3-none-any.whl", hash = "sha256:b699f1f24b24fa2747c05e2daa280aa64478a51e01a4e82c7f8e20b6167dfa99"},
-    {file = "langchain_core-0.3.67.tar.gz", hash = "sha256:2c14aa44a0e78e014e96d7f2f8916ac109d0a0ba87ed67ee25bf7296bed7e7ba"},
+    {file = "langchain_core-0.3.68-py3-none-any.whl", hash = "sha256:5e5c1fbef419590537c91b8c2d86af896fbcbaf0d5ed7fdcdd77f7d8f3467ba0"},
+    {file = "langchain_core-0.3.68.tar.gz", hash = "sha256:312e1932ac9aa2eaf111b70fdc171776fa571d1a86c1f873dcac88a094b19c6f"},
 ]
 
 [package.dependencies]
@@ -1625,14 +1625,14 @@ urllib3 = ">=2"
 
 [[package]]
 name = "typing-extensions"
-version = "4.14.0"
+version = "4.14.1"
 description = "Backported and Experimental Type Hints for Python 3.9+"
 optional = false
 python-versions = ">=3.9"
 groups = ["main", "test", "typing"]
 files = [
-    {file = "typing_extensions-4.14.0-py3-none-any.whl", hash = "sha256:a1514509136dd0b477638fc68d6a91497af5076466ad0fa6c338e44e359944af"},
-    {file = "typing_extensions-4.14.0.tar.gz", hash = "sha256:8676b788e32f02ab42d9e7c61324048ae4c6d844a399eebace3d4979d75ceef4"},
+    {file = "typing_extensions-4.14.1-py3-none-any.whl", hash = "sha256:d1e1e3b58374dc93031d6eda2420a48ea44a36c2b4766a4fdeb3710755731d76"},
+    {file = "typing_extensions-4.14.1.tar.gz", hash = "sha256:38b39f4aeeab64884ce9f74c94263ef78f3c22467c8724005483154c26648d36"},
 ]
 
 [[package]]

--- a/libs/ibm/tests/integration_tests/test_embeddings.py
+++ b/libs/ibm/tests/integration_tests/test_embeddings.py
@@ -20,6 +20,18 @@ MODEL_ID = "ibm/slate-125m-english-rtrvr"
 DOCUMENTS = ["What is a generative ai?", "What is a loan and how does it works?"]
 
 
+def test_init_with_credentials() -> None:
+    watsonx_embedding = WatsonxEmbeddings(
+        model_id=MODEL_ID,
+        url="https://us-south.ml.cloud.ibm.com",  # type: ignore[arg-type]
+        apikey=WX_APIKEY,  # type: ignore[arg-type]
+        project_id=WX_PROJECT_ID,
+    )
+    generate_embedding = watsonx_embedding.embed_documents(texts=DOCUMENTS)
+    assert len(generate_embedding) == len(DOCUMENTS)
+    assert all(isinstance(el, float) for el in generate_embedding[0])
+
+
 def test_init_with_client() -> None:
     watsonx_client = APIClient(
         credentials={
@@ -61,6 +73,17 @@ def test_01_generate_embed_documents() -> None:
         project_id=WX_PROJECT_ID,
     )
     generate_embedding = watsonx_embedding.embed_documents(texts=DOCUMENTS)
+    assert len(generate_embedding) == len(DOCUMENTS)
+    assert all(isinstance(el, float) for el in generate_embedding[0])
+
+
+async def test_01_generate_aembed_documents() -> None:
+    watsonx_embedding = WatsonxEmbeddings(
+        model_id=MODEL_ID,
+        url=URL,  # type: ignore[arg-type]
+        project_id=WX_PROJECT_ID,
+    )
+    generate_embedding = await watsonx_embedding.aembed_documents(texts=DOCUMENTS)
     assert len(generate_embedding) == len(DOCUMENTS)
     assert all(isinstance(el, float) for el in generate_embedding[0])
 
@@ -120,6 +143,18 @@ def test_10_generate_embed_query() -> None:
         project_id=WX_PROJECT_ID,
     )
     generate_embedding = watsonx_embedding.embed_query(text=DOCUMENTS[0])
+    assert isinstance(generate_embedding, list) and isinstance(
+        generate_embedding[0], float
+    )
+
+
+async def test_10_generate_aembed_query() -> None:
+    watsonx_embedding = WatsonxEmbeddings(
+        model_id=MODEL_ID,
+        url=URL,  # type: ignore[arg-type]
+        project_id=WX_PROJECT_ID,
+    )
+    generate_embedding = await watsonx_embedding.aembed_query(text=DOCUMENTS[0])
     assert isinstance(generate_embedding, list) and isinstance(
         generate_embedding[0], float
     )

--- a/libs/ibm/tests/integration_tests/test_embeddings_gateway.py
+++ b/libs/ibm/tests/integration_tests/test_embeddings_gateway.py
@@ -1,0 +1,101 @@
+import os
+
+import pytest
+from ibm_watsonx_ai import APIClient, Credentials  # type: ignore
+
+from langchain_ibm import WatsonxEmbeddings
+
+URL = "https://us-south.ml.cloud.ibm.com"
+WX_APIKEY = os.environ.get("WATSONX_APIKEY", "")
+WX_PROJECT_ID = os.environ.get("WATSONX_PROJECT_ID", "")
+
+MODEL = "ibm/granite-embedding-107m-multilingual"
+
+
+@pytest.mark.skip("Until not released on us-south, should be skipped.")
+class TestEmbeddingsGateway:
+    documents = ["What is a generative ai?", "What is a loan and how does it works?"]
+
+    def test_embedding_model_gateway_init_credentials(self) -> None:
+        watsonx_embedding = WatsonxEmbeddings(
+            model=MODEL,
+            url=URL,  # type: ignore[arg-type]
+            apikey=WX_APIKEY,  # type: ignore[arg-type]
+            project_id=WX_PROJECT_ID,
+        )
+        assert isinstance(watsonx_embedding, WatsonxEmbeddings)
+
+        response = watsonx_embedding.embed_query(text=self.documents[0])
+        assert response
+
+    def test_embedding_model_gateway_init_client(self) -> None:
+        credentials = Credentials(url=URL, api_key=WX_APIKEY)
+        api_client = APIClient(credentials=credentials, project_id=WX_PROJECT_ID)
+
+        watsonx_embedding = WatsonxEmbeddings(model=MODEL, watsonx_client=api_client)
+        assert isinstance(watsonx_embedding, WatsonxEmbeddings)
+
+        response = watsonx_embedding.embed_query(text=self.documents[0])
+        assert response
+
+    def test_embedding_model_gateway_embed_query(self) -> None:
+        watsonx_embedding = WatsonxEmbeddings(
+            model=MODEL,
+            url=URL,  # type: ignore[arg-type]
+            apikey=WX_APIKEY,  # type: ignore[arg-type]
+            project_id=WX_PROJECT_ID,
+        )
+        generate_embedding = watsonx_embedding.embed_query(text=self.documents[0])
+        assert isinstance(generate_embedding, list)
+        assert isinstance(generate_embedding[0], float)
+
+    async def test_embedding_model_gateway_aembed_query(self) -> None:
+        watsonx_embedding = WatsonxEmbeddings(
+            model=MODEL,
+            url=URL,  # type: ignore[arg-type]
+            apikey=WX_APIKEY,  # type: ignore[arg-type]
+            project_id=WX_PROJECT_ID,
+        )
+        generate_embedding = await watsonx_embedding.aembed_query(
+            text=self.documents[0]
+        )
+        assert isinstance(generate_embedding, list)
+        assert isinstance(generate_embedding[0], float)
+
+    def test_embedding_model_gateway_embed_documents(self) -> None:
+        watsonx_embedding = WatsonxEmbeddings(
+            model=MODEL,
+            url=URL,  # type: ignore[arg-type]
+            apikey=WX_APIKEY,  # type: ignore[arg-type]
+            project_id=WX_PROJECT_ID,
+        )
+        generate_embedding = watsonx_embedding.embed_documents(texts=self.documents)
+        assert generate_embedding
+        assert len(generate_embedding) == len(self.documents)
+        assert all(isinstance(embedding, list) for embedding in generate_embedding)
+        assert all(isinstance(embedding[0], float) for embedding in generate_embedding)
+        assert len(generate_embedding[0]) > 0
+        assert all(
+            len(embedding) == len(generate_embedding[0])
+            for embedding in generate_embedding
+        )
+
+    async def test_embedding_model_gateway_aembed_documents(self) -> None:
+        watsonx_embedding = WatsonxEmbeddings(
+            model=MODEL,
+            url=URL,  # type: ignore[arg-type]
+            apikey=WX_APIKEY,  # type: ignore[arg-type]
+            project_id=WX_PROJECT_ID,
+        )
+        generate_embedding = await watsonx_embedding.aembed_documents(
+            texts=self.documents
+        )
+        assert generate_embedding
+        assert len(generate_embedding) == len(self.documents)
+        assert all(isinstance(embedding, list) for embedding in generate_embedding)
+        assert all(isinstance(embedding[0], float) for embedding in generate_embedding)
+        assert len(generate_embedding[0]) > 0
+        assert all(
+            len(embedding) == len(generate_embedding[0])
+            for embedding in generate_embedding
+        )

--- a/libs/ibm/tests/integration_tests/test_embeddings_standard.py
+++ b/libs/ibm/tests/integration_tests/test_embeddings_standard.py
@@ -10,7 +10,7 @@ WX_PROJECT_ID = os.environ.get("WATSONX_PROJECT_ID", "")
 
 URL = "https://us-south.ml.cloud.ibm.com"
 
-MODEL_ID = "ibm/slate-125m-english-rtrvr"
+MODEL_ID = "ibm/granite-embedding-107m-multilingual"
 
 
 class TestWatsonxEmbeddingsStandard(EmbeddingsIntegrationTests):

--- a/libs/ibm/tests/unit_tests/test_chat_models.py
+++ b/libs/ibm/tests/unit_tests/test_chat_models.py
@@ -35,18 +35,16 @@ def test_initialize_chat_watsonx_bad_path_without_url() -> None:
             model_id=MODEL_ID,
         )
 
-    assert "url" in e.value.__str__()
-    assert "WATSONX_URL" in e.value.__str__()
+    assert "url" in str(e.value)
+    assert "WATSONX_URL" in str(e.value)
 
 
 def test_initialize_chat_watsonx_cloud_bad_path() -> None:
     with pytest.raises(ValueError) as e:
         ChatWatsonx(model_id=MODEL_ID, url="https://us-south.ml.cloud.ibm.com")  # type: ignore[arg-type]
 
-    assert "apikey" in e.value.__str__() and "token" in e.value.__str__()
-    assert (
-        "WATSONX_APIKEY" in e.value.__str__() and "WATSONX_TOKEN" in e.value.__str__()
-    )
+    assert "apikey" in str(e.value) and "token" in str(e.value)
+    assert "WATSONX_APIKEY" in str(e.value) and "WATSONX_TOKEN" in str(e.value)
 
 
 def test_initialize_chat_watsonx_cpd_bad_path_without_all() -> None:
@@ -56,14 +54,14 @@ def test_initialize_chat_watsonx_cpd_bad_path_without_all() -> None:
             url="https://cpd-zen.apps.cpd48.cp.fyre.ibm.com",  # type: ignore[arg-type]
         )
     assert (
-        "apikey" in e.value.__str__()
-        and "password" in e.value.__str__()
-        and "token" in e.value.__str__()
+        "apikey" in str(e.value)
+        and "password" in str(e.value)
+        and "token" in str(e.value)
     )
     assert (
-        "WATSONX_APIKEY" in e.value.__str__()
-        and "WATSONX_PASSWORD" in e.value.__str__()
-        and "WATSONX_TOKEN" in e.value.__str__()
+        "WATSONX_APIKEY" in str(e.value)
+        and "WATSONX_PASSWORD" in str(e.value)
+        and "WATSONX_TOKEN" in str(e.value)
     )
 
 
@@ -74,8 +72,8 @@ def test_initialize_chat_watsonx_cpd_bad_path_password_without_username() -> Non
             url="https://cpd-zen.apps.cpd48.cp.fyre.ibm.com",  # type: ignore[arg-type]
             password="test_password",  # type: ignore[arg-type]
         )
-    assert "username" in e.value.__str__()
-    assert "WATSONX_USERNAME" in e.value.__str__()
+    assert "username" in str(e.value)
+    assert "WATSONX_USERNAME" in str(e.value)
 
 
 def test_initialize_chat_watsonx_cpd_bad_path_apikey_without_username() -> None:
@@ -86,8 +84,8 @@ def test_initialize_chat_watsonx_cpd_bad_path_apikey_without_username() -> None:
             apikey="test_apikey",  # type: ignore[arg-type]
         )
 
-    assert "username" in e.value.__str__()
-    assert "WATSONX_USERNAME" in e.value.__str__()
+    assert "username" in str(e.value)
+    assert "WATSONX_USERNAME" in str(e.value)
 
 
 def test_initialize_chat_watsonx_cpd_bad_path_without_instance_id() -> None:
@@ -98,8 +96,8 @@ def test_initialize_chat_watsonx_cpd_bad_path_without_instance_id() -> None:
             apikey="test_apikey",  # type: ignore[arg-type]
             username="test_user",  # type: ignore[arg-type]
         )
-    assert "instance_id" in e.value.__str__()
-    assert "WATSONX_INSTANCE_ID" in e.value.__str__()
+    assert "instance_id" in str(e.value)
+    assert "WATSONX_INSTANCE_ID" in str(e.value)
 
 
 def test_initialize_chat_watsonx_with_two_exclusive_parameters() -> None:
@@ -114,7 +112,7 @@ def test_initialize_chat_watsonx_with_two_exclusive_parameters() -> None:
     assert (
         "The parameters 'model', 'model_id' and 'deployment_id' are mutually exclusive."
         " Please specify exactly one of these parameters when initializing ChatWatsonx."
-        in e.value.__str__()
+        in str(e.value)
     )
 
 
@@ -131,7 +129,7 @@ def test_initialize_chat_watsonx_with_three_exclusive_parameters() -> None:
     assert (
         "The parameters 'model', 'model_id' and 'deployment_id' are mutually exclusive."
         " Please specify exactly one of these parameters when initializing ChatWatsonx."
-        in e.value.__str__()
+        in str(e.value)
     )
 
 
@@ -141,7 +139,7 @@ def test_initialize_chat_watsonx_with_api_client_only() -> None:
     assert (
         "The parameters 'model', 'model_id' and 'deployment_id' are mutually exclusive."
         " Please specify exactly one of these parameters when initializing ChatWatsonx."
-        in e.value.__str__()
+        in str(e.value)
     )
 
 
@@ -150,7 +148,7 @@ def test_initialize_chat_watsonx_with_watsonx_model_gateway() -> None:
         ChatWatsonx(watsonx_model_gateway=gateway_mock)
     assert (
         "Passing the 'watsonx_model_gateway' parameter to the ChatWatsonx "
-        "constructor is not supported yet." in e.value.__str__()
+        "constructor is not supported yet." in str(e.value)
     )
 
 
@@ -160,7 +158,7 @@ def test_initialize_chat_watsonx_without_any_params() -> None:
     assert (
         "The parameters 'model', 'model_id' and 'deployment_id' are mutually exclusive."
         " Please specify exactly one of these parameters when initializing ChatWatsonx."
-        in e.value.__str__()
+        in str(e.value)
     )
 
 


### PR DESCRIPTION
# Added support for Model Gateway (Embeddings) in `langchain-ibm`

Compatible with 1.3.28 version of `ibm_watsonx_ai`

## Implementation TODO:
- [x] Added support for Model Gateway (Embeddings)
- [x] Added async methods for  Added async methods

## Initialise`WatsonxEmbeddings` with Model Gateway (model):

```python
from langchain_ibm import WatsonxEmbeddings

from ibm_watsonx_ai import APIClient
from ibm_watsonx_ai.gateway import Gateway

# with credentials
embeddings = WatsonxEmbeddings(
    model="ibm/granite-embedding-107m-multilingual",
    url=<URL>,
    apikey=<APIKEY>,
    project_id=<PROJECT_ID>
)

# with api_client object
api_client = APIClient(...)
embeddings = WatsonxEmbeddings(
    model="ibm/granite-embedding-107m-multilingual",
    watsonx_client=api_client
)
```

## Tests:

- [x] Added `WatsonxEmbeddings` test with Model Gateway (TestEmbeddingsGateway)

Local screenshot with test run on test environment:

![Screenshot 2025-07-07 at 12 39 24](https://github.com/user-attachments/assets/f2d27513-a4d3-45e3-8075-b350ce8ead5a)


