### PR TITLE
[langchain-ibm] Release 0.3.15

### DIFF
--- a/libs/ibm/pyproject.toml
+++ b/libs/ibm/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langchain-ibm"
-version = "0.3.14"
+version = "0.3.15"
 description = "An integration package connecting IBM watsonx.ai and LangChain"
 authors = ["IBM"]
 readme = "README.md"


### PR DESCRIPTION
[langchain-ibm] Release 0.3.15

- [x] Added support for Model Gateway in `WatsonxEmbeddings` - https://github.com/langchain-ai/langchain-ibm/pull/88
- [x] Added support for Model Gateway in `WatsonxLLM` - https://github.com/langchain-ai/langchain-ibm/pull/90