### PR TITLE
[langchain-ibm/feat]: Added support for Model Gateway (WatsonxLLM)

### DIFF
--- a/libs/ibm/langchain_ibm/llms.py
+++ b/libs/ibm/langchain_ibm/llms.py
@@ -678,7 +678,7 @@ class WatsonxLLM(BaseLLM):
     def get_num_tokens(self, text: str) -> int:
         if self.watsonx_model_gateway is not None:
             raise NotImplementedError(
-                "Model Gateway do not support tokenize endpoint yet."
+                "Tokenize endpoint is not supported by IBM Model Gateway endpoint."
             )
         else:
             response = self.watsonx_model.tokenize(text, return_tokens=False)

--- a/libs/ibm/tests/integration_tests/test_llm_gateway.py
+++ b/libs/ibm/tests/integration_tests/test_llm_gateway.py
@@ -1,0 +1,111 @@
+import os
+
+import pytest
+from ibm_watsonx_ai import APIClient, Credentials  # type: ignore
+
+from langchain_ibm import WatsonxLLM
+
+URL = "https://us-south.ml.cloud.ibm.com"
+WX_APIKEY = os.environ.get("WATSONX_APIKEY", "")
+WX_PROJECT_ID = os.environ.get("WATSONX_PROJECT_ID", "")
+
+MODEL = "ibm/granite-3-8b-instruct"
+
+
+@pytest.mark.skip("Until not released on us-south, should be skipped.")
+class TestLLMGateway:
+    prompt = "Hello, How are you!"
+
+    def test_llm_model_gateway_init_credentials(self) -> None:
+        chat = WatsonxLLM(
+            model=MODEL,
+            url=URL,  # type: ignore[arg-type]
+            apikey=WX_APIKEY,  # type: ignore[arg-type]
+            project_id=WX_PROJECT_ID,
+        )
+        assert isinstance(chat, WatsonxLLM)
+
+        response = chat.invoke(self.prompt)
+
+        assert response
+        assert isinstance(response, str)
+
+    def test_llm_model_gateway_init_client(self) -> None:
+        credentials = Credentials(url=URL, api_key=WX_APIKEY)
+        api_client = APIClient(credentials=credentials, project_id=WX_PROJECT_ID)
+
+        chat = WatsonxLLM(model=MODEL, watsonx_client=api_client)
+        assert isinstance(chat, WatsonxLLM)
+
+        response = chat.invoke(self.prompt)
+
+        assert response
+        assert isinstance(response, str)
+
+    def test_llm_model_gateway_invoke(self) -> None:
+        chat = WatsonxLLM(
+            model=MODEL,
+            url=URL,  # type: ignore[arg-type]
+            apikey=WX_APIKEY,  # type: ignore[arg-type]
+            project_id=WX_PROJECT_ID,
+        )
+        response = chat.invoke(self.prompt)
+        assert response
+        assert isinstance(response, str)
+
+    async def test_llm_model_gateway_ainvoke(self) -> None:
+        chat = WatsonxLLM(
+            model=MODEL,
+            url=URL,  # type: ignore[arg-type]
+            apikey=WX_APIKEY,  # type: ignore[arg-type]
+            project_id=WX_PROJECT_ID,
+        )
+        response = await chat.ainvoke(self.prompt)
+        assert response
+        assert isinstance(response, str)
+
+    def test_llm_model_gateway_generate(self) -> None:
+        chat = WatsonxLLM(
+            model=MODEL,
+            url=URL,  # type: ignore[arg-type]
+            apikey=WX_APIKEY,  # type: ignore[arg-type]
+            project_id=WX_PROJECT_ID,
+        )
+        response = chat.generate(["What color sunflower is?"])
+        assert response
+        for generation in response.generations:
+            assert generation[0].text
+
+    async def test_llm_model_gateway_agenerate(self) -> None:
+        chat = WatsonxLLM(
+            model=MODEL,
+            url=URL,  # type: ignore[arg-type]
+            apikey=WX_APIKEY,  # type: ignore[arg-type]
+            project_id=WX_PROJECT_ID,
+        )
+        response = await chat.agenerate(["What color sunflower is?"])
+        assert response
+        for generation in response.generations:
+            assert generation[0].text
+
+    def test_chat_model_gateway_stream(self) -> None:
+        chat = WatsonxLLM(
+            model=MODEL,
+            url=URL,  # type: ignore[arg-type]
+            apikey=WX_APIKEY,  # type: ignore[arg-type]
+            project_id=WX_PROJECT_ID,
+        )
+        response = chat.stream(self.prompt)
+        for chunk in response:
+            assert isinstance(chunk, str)
+
+    async def test_chat_model_gateway_astream(self) -> None:
+        chat = WatsonxLLM(
+            model=MODEL,
+            url=URL,  # type: ignore[arg-type]
+            apikey=WX_APIKEY,  # type: ignore[arg-type]
+            project_id=WX_PROJECT_ID,
+        )
+        response = chat.astream(self.prompt)
+        async for chunk in response:
+            assert isinstance(chunk, str)

--- a/libs/ibm/tests/unit_tests/test_chat_models.py
+++ b/libs/ibm/tests/unit_tests/test_chat_models.py
@@ -162,7 +162,7 @@ def test_initialize_chat_watsonx_without_any_params() -> None:
     )
 
 
-def test_initialize_chat_watsonx_with_model_inferencey_only() -> None:
+def test_initialize_chat_watsonx_with_model_inference_only() -> None:
     chat = ChatWatsonx(watsonx_model=model_inference_mock)
 
     assert isinstance(chat, ChatWatsonx)


### PR DESCRIPTION
# Added support for Model Gateway (WatsonxLLM) in `langchain-ibm`

Compatible with 1.3.28 version of `ibm_watsonx_ai`

## Implementation TODO:
- [x] Added support for Model Gateway (WatsonxLLM)

## Initialise`WatsonxLLM` with Model Gateway (model):

```python
from langchain_ibm import WatsonxLLM

from ibm_watsonx_ai import APIClient
from ibm_watsonx_ai.gateway import Gateway

# with credentials
embeddings = WatsonxLLM(
    model="ibm/granite-3-8b-instruct",
    url=<URL>,
    apikey=<APIKEY>,
    project_id=<PROJECT_ID>
)

# with api_client object
api_client = APIClient(...)
embeddings = WatsonxLLM(
    model="ibm/granite-3-8b-instruct"
    watsonx_client=api_client
)
```

## Tests:

- [x] Added `WatsonxLLM` test with Model Gateway (TestLLMGateway)

Local screenshot with test run on test environment:
![Screenshot 2025-07-08 at 17 01 40](https://github.com/user-attachments/assets/a80dcaec-9c73-416e-bac0-b54355165e01)


