### PR TITLE
[langchain-ibm/feat]: Support for CPD in WatsonxToolkit

### DIFF
--- a/libs/ibm/tests/unit_tests/test_toolkit.py
+++ b/libs/ibm/tests/unit_tests/test_toolkit.py
@@ -29,3 +29,12 @@ def test_initialize_watsonx_toolkit_cloud_bad_api_key() -> None:
     except ValueError as e:
         assert "apikey" in e.__str__() and "token" in e.__str__()
         assert "WATSONX_APIKEY" in e.__str__() and "WATSONX_TOKEN" in e.__str__()
+
+
+def test_initialize_watsonx_toolkit_cpd_invalid_credentials() -> None:
+    try:
+        WatsonxToolkit(url="https://cpd-cpd-instance.apps.sample.cp.fyre.ibm.com")  # type: ignore[arg-type]
+    except ValueError as e:
+        assert "username" in e.__str__()
+        assert "password" in e.__str__()
+        assert "instance_id" in e.__str__()


### PR DESCRIPTION
We should be able now to create WatsonxToolkit with provided credentials to CPD:
```python
from langchain_ibm.agent_toolkits.utility import WatsonxToolkit

watsonx_toolkit = WatsonxToolkit(
    url="<CPD_URL>",
    username="<USERNAME>",
    password="<PASSWORD>",
    instance_id="<INSTANCE_ID>",
    version='<VERSION>'  # optional
)
```
Result of `make test`:
```
88 passed, 2 skipped, 2 warnings in 1.46s 
```