### PR TITLE
chore: improve WatsonxSQLDatabase with method get_n_first_rows

### DIFF
--- a/libs/ibm/langchain_ibm/utilities/sql_database.py
+++ b/libs/ibm/langchain_ibm/utilities/sql_database.py
@@ -368,11 +368,6 @@ class WatsonxSQLDatabase:
             if missing_tables:
                 raise ValueError(f"table_names {missing_tables} not found in database")
 
-        extra_interaction_properties = {
-            "schema_name": self.schema,
-            "row_limit": self._sample_rows_in_table_info,
-        }
-
         with self._flight_sql_client as flight_sql_client:
             if table_names is None:
                 table_names = self._all_tables
@@ -386,10 +381,10 @@ class WatsonxSQLDatabase:
                     )
                     + f"\n\nFirst {self._sample_rows_in_table_info} rows "
                     + f"of table {table_name}:\n\n"
-                    + flight_sql_client.execute(
-                        None,
-                        interaction_properties=extra_interaction_properties
-                        | {"table_name": table_name},
+                    + flight_sql_client.get_n_first_rows(
+                        schema=self.schema,
+                        table_name=table_name,
+                        n=self._sample_rows_in_table_info,
                     ).to_string()
                     for table_name in table_names
                 ]

--- a/libs/ibm/tests/unit_tests/utilities/test_sql_database.py
+++ b/libs/ibm/tests/unit_tests/utilities/test_sql_database.py
@@ -95,9 +95,7 @@ class MockFlightSQLClient:
             raise flight.FlightError("Table not found")
 
     def execute(self, *args: Any, **kwargs: Any) -> pd.DataFrame:
-        if kwargs.get("interaction_properties", {}).get("table_name") == "table1" or (
-            "table1" in kwargs.get("query", "")
-        ):
+        if "table1" in kwargs.get("query", ""):
             return pd.DataFrame({"id": [1], "name": ["test"], "age": [35]})
 
         elif "table1" not in kwargs.get("query", ""):
@@ -105,6 +103,11 @@ class MockFlightSQLClient:
 
         else:
             raise ValueError("syntax error")
+
+    def get_n_first_rows(
+        self, schema: str, table_name: str, n: int = 3
+    ) -> pd.DataFrame:
+        return pd.DataFrame({"id": [1], "name": ["test"], "age": [35]})
 
 
 ### truncate_word


### PR DESCRIPTION
The goal of this changes is to simplify the logic and reuse `FlightSQLClient.get_n_first_rows` that were publish in SDK 1.3.36