### PR TITLE
fix: improve returning table info

### DIFF
--- a/libs/ibm/langchain_ibm/utilities/sql_database.py
+++ b/libs/ibm/langchain_ibm/utilities/sql_database.py
@@ -56,10 +56,10 @@ def pretty_print_table_info(schema: str, table_name: str, table_info: dict) -> s
         native_type = field_metadata_type.get("native_type")
         nullable = field_metadata_type.get("nullable")
 
-        return f"{name} {native_type}{'' if nullable else ' NOT NULL'}"
+        return f'"{name}" {native_type}{"" if nullable else " NOT NULL"}'
 
     create_table_template = """
-CREATE TABLE {schema}.{table_name} (
+CREATE TABLE "{schema}"."{table_name}" (
 \t{column_definitions}{primary_key}{foreign_key}
 \t)"""
 

--- a/libs/ibm/tests/unit_tests/utilities/test_sql_database.py
+++ b/libs/ibm/tests/unit_tests/utilities/test_sql_database.py
@@ -142,10 +142,10 @@ def test_pretty_print_table_info(
     schema: str, table_name: str, table_info: dict
 ) -> None:
     expected_output = """
-CREATE TABLE test_schema.test_table (
-\tid INT NOT NULL,
-\tname VARCHAR(255),
-\tage INT,
+CREATE TABLE "test_schema"."test_table" (
+\t"id" INT NOT NULL,
+\t"name" VARCHAR(255),
+\t"age" INT,
 \tCONSTRAINT primary_key PRIMARY KEY (id)
 \t)"""
     assert pretty_print_table_info(schema, table_name, table_info) == expected_output
@@ -170,9 +170,9 @@ def test_pretty_print_table_info_with_nullable_columns() -> None:
         ],
     }
     expected_output = """
-CREATE TABLE another_schema.another_table (
-\temail VARCHAR(255),
-\tcreated_at TIMESTAMP,
+CREATE TABLE "another_schema"."another_table" (
+\t"email" VARCHAR(255),
+\t"created_at" TIMESTAMP,
 \tCONSTRAINT primary_key PRIMARY KEY (email)
 \t)"""
     assert pretty_print_table_info(schema, table_name, table_info) == expected_output
@@ -191,9 +191,9 @@ def test_pretty_print_table_info_without_primary_key() -> None:
         ]
     }
     expected_output = """
-CREATE TABLE no_pk_schema.no_pk_table (
-\tvalue1 INT NOT NULL,
-\tvalue2 VARCHAR(255)
+CREATE TABLE "no_pk_schema"."no_pk_table" (
+\t"value1" INT NOT NULL,
+\t"value2" VARCHAR(255)
 \t)"""
     assert pretty_print_table_info(schema, table_name, table_info) == expected_output
 
@@ -421,10 +421,10 @@ def test_initialize_watsonx_sql_database_get_table_info(
 
         wx_sql_database = WatsonxSQLDatabase(connection_id=CONNECTION_ID, schema=schema)
         expected_output = """
-CREATE TABLE test_schema.table1 (
-\tid INT NOT NULL,
-\tname VARCHAR(255),
-\tage INT,
+CREATE TABLE "test_schema"."table1" (
+\t"id" INT NOT NULL,
+\t"name" VARCHAR(255),
+\t"age" INT,
 \tCONSTRAINT primary_key PRIMARY KEY (id)
 \t)
 


### PR DESCRIPTION
If column of table name contains space then it should be encapsulated with `""`.

currently:

```
CREATE TABLE public.sales_stats (
	gender CHARACTER VARYING,
	age INTEGER,
	marital_status CHARACTER VARYING,
	profession CHARACTER VARYING,
	product_line CHARACTER VARYING,
	CONSTRAINT primary_key PRIMARY KEY ()
	)

First 3 rows of table sales_stats:

gender  age marital_status   profession             product_line
     M   27         Single Professional     Personal Accessories
     F   39         Single    Executive     Personal Accessories
     M   39        Married      Student Mountaineering Equipment
```

Proposition:
```
CREATE TABLE "public"."sales_stats" (
	"gender" CHARACTER VARYING,
	"age" INTEGER,
	"marital_status" CHARACTER VARYING,
	"profession" CHARACTER VARYING,
	"product_line" CHARACTER VARYING,
	CONSTRAINT primary_key PRIMARY KEY ()
	)

First 3 rows of table sales_stats:

gender  age marital_status   profession             product_line
     M   27         Single Professional     Personal Accessories
     F   39         Single    Executive     Personal Accessories
     M   39        Married      Student Mountaineering Equipment
```