### PR TITLE
[langchain-ibm]: Release 0.3.19

### DIFF
--- a/libs/ibm/pyproject.toml
+++ b/libs/ibm/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langchain-ibm"
-version = "0.3.18"
+version = "0.3.19"
 description = "An integration package connecting IBM watsonx.ai and LangChain"
 authors = ["IBM"]
 readme = "README.md"


### PR DESCRIPTION
[langchain-ibm]: Release 0.3.19

- [Updating reference docs for new site v1 (langchain-ibm)](https://github.com/langchain-ai/langchain-ibm/pull/122)
- [Updating reference docs for new site v2 (langchain-db2)](https://github.com/langchain-ai/langchain-ibm/pull/123)
- [Added support for reasoning_content field](https://github.com/langchain-ai/langchain-ibm/pull/124)