### PR TITLE
chore(langchain-ibm): follow ibm_watsonx_ai untyped imports

### DIFF
--- a/libs/ibm/langchain_ibm/agent_toolkits/utility/toolkit.py
+++ b/libs/ibm/langchain_ibm/agent_toolkits/utility/toolkit.py
@@ -2,8 +2,8 @@
 
 from typing import Any, cast
 
-from ibm_watsonx_ai import APIClient  # type: ignore[import-untyped]
-from ibm_watsonx_ai.foundation_models.utils import (  # type: ignore[import-untyped]
+from ibm_watsonx_ai import APIClient
+from ibm_watsonx_ai.foundation_models.utils import (
     Tool,
     Toolkit,
 )

--- a/libs/ibm/langchain_ibm/utilities/sql_database.py
+++ b/libs/ibm/langchain_ibm/utilities/sql_database.py
@@ -14,8 +14,8 @@ except ModuleNotFoundError as e:
     )
     raise ModuleNotFoundError(error_msg) from e
 
-from ibm_watsonx_ai import APIClient, Credentials  # type: ignore[import-untyped]
-from ibm_watsonx_ai.helpers.connections.flight_sql_service import (  # type: ignore[import-untyped]
+from ibm_watsonx_ai import APIClient, Credentials
+from ibm_watsonx_ai.helpers.connections.flight_sql_service import (
     FlightSQLClient,
 )
 from langchain_core.utils.utils import from_env
@@ -316,16 +316,16 @@ class WatsonxSQLDatabase:
 
         else:
             self.watsonx_client = watsonx_client
-
-        context_id: dict[str, str | None] = {"project_id": None, "space_id": None}
+        client_project_id = None
+        client_space_id = None
         if project_id is not None:
-            context_id["project_id"] = project_id
+            client_project_id = project_id
         elif space_id is not None:
-            context_id["space_id"] = space_id
+            client_space_id = space_id
         elif self.watsonx_client.default_project_id is not None:
-            context_id["project_id"] = self.watsonx_client.default_project_id
+            client_project_id = self.watsonx_client.default_project_id  # type: ignore[unreachable]
         elif self.watsonx_client.default_space_id is not None:
-            context_id["space_id"] = self.watsonx_client.default_space_id
+            client_space_id = self.watsonx_client.default_space_id  # type: ignore[unreachable]
         else:
             error_msg = "Either project_id or space_id is required."
             raise ValueError(error_msg)
@@ -333,7 +333,8 @@ class WatsonxSQLDatabase:
         self._flight_sql_client = FlightSQLClient(
             connection_id=connection_id,
             api_client=self.watsonx_client,
-            **context_id,
+            project_id=client_project_id,
+            space_id=client_space_id,
         )
 
         with self._flight_sql_client as flight_sql_client:

--- a/libs/ibm/langchain_ibm/utils.py
+++ b/libs/ibm/langchain_ibm/utils.py
@@ -9,11 +9,11 @@ from copy import deepcopy
 from typing import Any, cast
 from urllib.parse import urlparse
 
-from ibm_watsonx_ai import APIClient, Credentials  # type: ignore[import-untyped]
-from ibm_watsonx_ai.foundation_models.schema import (  # type: ignore[import-untyped]
+from ibm_watsonx_ai import APIClient, Credentials
+from ibm_watsonx_ai.foundation_models.schema import (
     BaseSchema,
 )
-from ibm_watsonx_ai.wml_client_error import (  # type: ignore[import-untyped]
+from ibm_watsonx_ai.wml_client_error import (
     ApiRequestFailure,
 )
 from pydantic import SecretStr

--- a/libs/ibm/pyproject.toml
+++ b/libs/ibm/pyproject.toml
@@ -106,6 +106,10 @@ warn_unreachable = true
 disallow_any_generics = false
 warn_return_any = false
 
+[[tool.mypy.overrides]]
+module = "ibm_watsonx_ai.*"
+follow_untyped_imports = true
+
 [tool.coverage.run]
 omit = ["tests/*"]
 

--- a/libs/ibm/tests/integration_tests/test_chat_models.py
+++ b/libs/ibm/tests/integration_tests/test_chat_models.py
@@ -4,10 +4,10 @@ import re
 from typing import Any, Literal, cast
 
 import pytest
-from ibm_watsonx_ai.foundation_models.schema import (  # type: ignore[import-untyped]
+from ibm_watsonx_ai.foundation_models.schema import (
     TextChatParameters,
 )
-from ibm_watsonx_ai.metanames import (  # type: ignore[import-untyped]
+from ibm_watsonx_ai.metanames import (
     GenTextParamsMetaNames,
 )
 from langchain_core.messages import (

--- a/libs/ibm/tests/integration_tests/test_chat_models_gateway.py
+++ b/libs/ibm/tests/integration_tests/test_chat_models_gateway.py
@@ -1,7 +1,7 @@
 import os
 
 import pytest
-from ibm_watsonx_ai import APIClient, Credentials  # type: ignore[import-untyped]
+from ibm_watsonx_ai import APIClient, Credentials
 from langchain_core.messages import (
     HumanMessage,
     SystemMessage,

--- a/libs/ibm/tests/integration_tests/test_embeddings.py
+++ b/libs/ibm/tests/integration_tests/test_embeddings.py
@@ -6,11 +6,11 @@ You'll need to set WATSONX_APIKEY and WATSONX_PROJECT_ID environment variables.
 import os
 
 import pytest
-from ibm_watsonx_ai import APIClient  # type: ignore[import-untyped]
-from ibm_watsonx_ai.foundation_models.embeddings import (  # type: ignore[import-untyped]
+from ibm_watsonx_ai import APIClient
+from ibm_watsonx_ai.foundation_models.embeddings import (
     Embeddings,
 )
-from ibm_watsonx_ai.metanames import (  # type: ignore[import-untyped]
+from ibm_watsonx_ai.metanames import (
     EmbedTextParamsMetaNames,
 )
 

--- a/libs/ibm/tests/integration_tests/test_embeddings_gateway.py
+++ b/libs/ibm/tests/integration_tests/test_embeddings_gateway.py
@@ -1,7 +1,7 @@
 import os
 
 import pytest
-from ibm_watsonx_ai import APIClient, Credentials  # type: ignore[import-untyped]
+from ibm_watsonx_ai import APIClient, Credentials
 
 from langchain_ibm import WatsonxEmbeddings
 

--- a/libs/ibm/tests/integration_tests/test_llms.py
+++ b/libs/ibm/tests/integration_tests/test_llms.py
@@ -6,15 +6,15 @@ You'll need to set WATSONX_APIKEY and WATSONX_PROJECT_ID environment variables.
 import os
 
 import pytest
-from ibm_watsonx_ai import APIClient, Credentials  # type: ignore[import-untyped]
-from ibm_watsonx_ai.foundation_models import (  # type: ignore[import-untyped]
+from ibm_watsonx_ai import APIClient, Credentials
+from ibm_watsonx_ai.foundation_models import (
     Model,
     ModelInference,
 )
-from ibm_watsonx_ai.foundation_models.utils.enums import (  # type: ignore[import-untyped]
+from ibm_watsonx_ai.foundation_models.utils.enums import (
     DecodingMethods,
 )
-from ibm_watsonx_ai.metanames import (  # type: ignore[import-untyped]
+from ibm_watsonx_ai.metanames import (
     GenTextParamsMetaNames,
 )
 from langchain_core.outputs import LLMResult

--- a/libs/ibm/tests/integration_tests/test_llms_gateway.py
+++ b/libs/ibm/tests/integration_tests/test_llms_gateway.py
@@ -1,7 +1,7 @@
 import os
 
 import pytest
-from ibm_watsonx_ai import APIClient, Credentials  # type: ignore[import-untyped]
+from ibm_watsonx_ai import APIClient, Credentials
 
 from langchain_ibm import WatsonxLLM
 

--- a/libs/ibm/tests/integration_tests/test_rerank.py
+++ b/libs/ibm/tests/integration_tests/test_rerank.py
@@ -1,8 +1,8 @@
 import os
 
 import pytest
-from ibm_watsonx_ai import APIClient  # type: ignore[import-untyped]
-from ibm_watsonx_ai.foundation_models.schema import (  # type: ignore[import-untyped]
+from ibm_watsonx_ai import APIClient
+from ibm_watsonx_ai.foundation_models.schema import (
     RerankParameters,
     RerankReturnOptions,
 )

--- a/libs/ibm/tests/integration_tests/test_tools_standard.py
+++ b/libs/ibm/tests/integration_tests/test_tools_standard.py
@@ -1,6 +1,6 @@
 import os
 
-from ibm_watsonx_ai import APIClient, Credentials  # type: ignore[import-untyped]
+from ibm_watsonx_ai import APIClient, Credentials
 from langchain_core.tools import BaseTool
 from langchain_tests.integration_tests.tools import ToolsIntegrationTests
 

--- a/libs/ibm/tests/unit_tests/test_chat_models.py
+++ b/libs/ibm/tests/unit_tests/test_chat_models.py
@@ -7,15 +7,15 @@ from typing import Any
 from unittest.mock import Mock
 
 import pytest
-from ibm_watsonx_ai import APIClient  # type: ignore[import-untyped]
-from ibm_watsonx_ai.foundation_models import (  # type: ignore[import-untyped]
+from ibm_watsonx_ai import APIClient
+from ibm_watsonx_ai.foundation_models import (
     ModelInference,
 )
-from ibm_watsonx_ai.foundation_models.schema import (  # type: ignore[import-untyped]
+from ibm_watsonx_ai.foundation_models.schema import (
     TextChatParameters,
 )
-from ibm_watsonx_ai.gateway import Gateway  # type: ignore[import-untyped]
-from ibm_watsonx_ai.wml_client_error import (  # type: ignore[import-untyped]
+from ibm_watsonx_ai.gateway import Gateway
+from ibm_watsonx_ai.wml_client_error import (
     WMLClientError,
 )
 

--- a/libs/ibm/tests/unit_tests/test_chat_models_standard.py
+++ b/libs/ibm/tests/unit_tests/test_chat_models_standard.py
@@ -1,25 +1,18 @@
-from ibm_watsonx_ai import APIClient, Credentials  # type: ignore[import-untyped]
-from ibm_watsonx_ai.service_instance import (  # type: ignore[import-untyped]
-    ServiceInstance,
-)
+import pytest
+from ibm_watsonx_ai import APIClient, Credentials
 from langchain_core.language_models import BaseChatModel
 from langchain_tests.unit_tests.chat_models import ChatModelUnitTests
+from pytest_mock import MockerFixture
 
 from langchain_ibm import ChatWatsonx
 
-client = APIClient.__new__(APIClient)
-client.CLOUD_PLATFORM_SPACES = True
-client.ICP_PLATFORM_SPACES = True
-credentials = Credentials(api_key="api_key")
-client.credentials = credentials
-client.service_instance = ServiceInstance.__new__(ServiceInstance)
-client.default_space_id = None
-client.default_project_id = None
-client._httpx_client = None
-client._async_httpx_client = None
-
 
 class TestWatsonxStandard(ChatModelUnitTests):
+    @pytest.fixture(autouse=True)
+    def setup_client(self, mocker: MockerFixture) -> None:
+        self.client = mocker.Mock(APIClient)
+        self.client.credentials = Credentials(api_key="api_key")
+
     @property
     def chat_model_class(self) -> type[BaseChatModel]:
         return ChatWatsonx
@@ -29,5 +22,5 @@ class TestWatsonxStandard(ChatModelUnitTests):
         return {
             "model_id": "ibm/granite-13b-instruct-v2",
             "validate_model": False,
-            "watsonx_client": client,
+            "watsonx_client": self.client,
         }

--- a/libs/ibm/tests/unit_tests/test_embeddings.py
+++ b/libs/ibm/tests/unit_tests/test_embeddings.py
@@ -5,12 +5,12 @@ import re
 from unittest.mock import Mock
 
 import pytest
-from ibm_watsonx_ai import APIClient  # type: ignore[import-untyped]
-from ibm_watsonx_ai.foundation_models.embeddings import (  # type: ignore[import-untyped]
+from ibm_watsonx_ai import APIClient
+from ibm_watsonx_ai.foundation_models.embeddings import (
     Embeddings,
 )
-from ibm_watsonx_ai.gateway import Gateway  # type: ignore[import-untyped]
-from ibm_watsonx_ai.wml_client_error import (  # type: ignore[import-untyped]
+from ibm_watsonx_ai.gateway import Gateway
+from ibm_watsonx_ai.wml_client_error import (
     WMLClientError,
 )
 

--- a/libs/ibm/tests/unit_tests/test_embeddings_standard.py
+++ b/libs/ibm/tests/unit_tests/test_embeddings_standard.py
@@ -1,22 +1,17 @@
-from ibm_watsonx_ai import APIClient, Credentials  # type: ignore[import-untyped]
-from ibm_watsonx_ai.service_instance import (  # type: ignore[import-untyped]
-    ServiceInstance,
-)
+import pytest
+from ibm_watsonx_ai import APIClient, Credentials
 from langchain_tests.unit_tests.embeddings import EmbeddingsUnitTests
+from pytest_mock import MockerFixture
 
 from langchain_ibm import WatsonxEmbeddings
 
-client = APIClient.__new__(APIClient)
-client.CLOUD_PLATFORM_SPACES = True
-client.ICP_PLATFORM_SPACES = True
-credentials = Credentials(api_key="api_key")
-client.credentials = credentials
-client.service_instance = ServiceInstance.__new__(ServiceInstance)
-client._httpx_client = None
-client._async_httpx_client = None
-
 
 class TestWatsonxEmbeddingsStandard(EmbeddingsUnitTests):
+    @pytest.fixture(autouse=True)
+    def setup_client(self, mocker: MockerFixture) -> None:
+        self.client = mocker.Mock(APIClient)
+        self.client.credentials = Credentials(api_key="api_key")
+
     @property
     def embeddings_class(self) -> type[WatsonxEmbeddings]:
         return WatsonxEmbeddings
@@ -25,5 +20,5 @@ class TestWatsonxEmbeddingsStandard(EmbeddingsUnitTests):
     def embedding_model_params(self) -> dict:
         return {
             "model_id": "ibm/granite-13b-instruct-v2",
-            "watsonx_client": client,
+            "watsonx_client": self.client,
         }

--- a/libs/ibm/tests/unit_tests/test_llms.py
+++ b/libs/ibm/tests/unit_tests/test_llms.py
@@ -5,13 +5,13 @@ import re
 from unittest.mock import Mock
 
 import pytest
-from ibm_watsonx_ai import APIClient  # type: ignore[import-untyped]
-from ibm_watsonx_ai.foundation_models import (  # type: ignore[import-untyped]
+from ibm_watsonx_ai import APIClient
+from ibm_watsonx_ai.foundation_models import (
     Model,
     ModelInference,
 )
-from ibm_watsonx_ai.gateway import Gateway  # type: ignore[import-untyped]
-from ibm_watsonx_ai.wml_client_error import (  # type: ignore[import-untyped]
+from ibm_watsonx_ai.gateway import Gateway
+from ibm_watsonx_ai.wml_client_error import (
     WMLClientError,
 )
 

--- a/libs/ibm/tests/unit_tests/test_rerank.py
+++ b/libs/ibm/tests/unit_tests/test_rerank.py
@@ -3,7 +3,7 @@
 import os
 
 import pytest
-from ibm_watsonx_ai.wml_client_error import (  # type: ignore[import-untyped]
+from ibm_watsonx_ai.wml_client_error import (
     WMLClientError,
 )
 

--- a/libs/ibm/tests/unit_tests/test_toolkit.py
+++ b/libs/ibm/tests/unit_tests/test_toolkit.py
@@ -3,7 +3,7 @@
 import os
 
 import pytest
-from ibm_watsonx_ai.wml_client_error import (  # type: ignore[import-untyped]
+from ibm_watsonx_ai.wml_client_error import (
     WMLClientError,
 )
 

--- a/libs/ibm/tests/unit_tests/test_tools_standard.py
+++ b/libs/ibm/tests/unit_tests/test_tools_standard.py
@@ -1,5 +1,5 @@
-from ibm_watsonx_ai import APIClient, Credentials  # type: ignore[import-untyped]
-from ibm_watsonx_ai.service_instance import (  # type: ignore[import-untyped]
+from ibm_watsonx_ai import APIClient, Credentials
+from ibm_watsonx_ai.service_instance import (
     ServiceInstance,
 )
 from langchain_core.tools import BaseTool


### PR DESCRIPTION
<!--
🙏 Thank you for contributing to LangChain-IBM!
Your time and effort help make the ecosystem stronger.
-->

## 📝 Description

### 💡 Summary of Changes
<!-- Briefly describe what this PR changes and why -->

This PR imports types from `ibm_watsonx_ai`.
Even though `ibm_watsonx_ai` doesn't have a `py.typed` file, it is correctly typed.
So we can use its types to get better type safety.

---

## ✅ PR Checklist

- [x] **PR Title Format:** `{TYPE}({SCOPE}): {DESCRIPTION}`
  - **Examples:**
    - feat(langchain-ibm): add multi-tenant support  
    - fix(langchain-db2): resolve flag parsing error  
    - docs(langchain-ibm): update API usage examples  
  - **Allowed `{TYPE}` values:**  
    `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`, `release`
  - **Allowed `{SCOPE}` values (optional):**  
    `langchain-ibm`, `langchain-db2`

- [x] **PR Description:** The *Description* section clearly lists what was changed, why, and how it was tested.

- [x] **Formatting, Linting & Tests**  
  Run the following commands from the root of the modified package(s):
  ```bash
  make format
  make lint
  make test
  ```
  ⚠️ PRs will only be considered if all checks pass in CI.  
  See the [contribution guidelines](https://docs.langchain.com/oss/python/contributing) for more details.

