### PR TITLE
fix(langchain-db2): Fix an issue with INSERT large dimension VECTOR.

### DIFF
--- a/libs/langchain-db2/langchain_db2/db2vs.py
+++ b/libs/langchain-db2/langchain_db2/db2vs.py
@@ -484,7 +484,7 @@ class DB2VS(VectorStore):
         sql_insert = (
             f"INSERT INTO "  # noqa: S608
             f"{self.table_name} (id, embedding, metadata, {self._text_field}) "
-            f"VALUES (?, VECTOR(cast(? as CLOB(50000)), {embedding_len}, FLOAT32), "
+            f"VALUES (?, VECTOR(cast(? as CLOB(100000)), {embedding_len}, FLOAT32), "
             f"SYSTOOLS.JSON2BSON(?), ?)"
         )
 


### PR DESCRIPTION
<!--
🙏 Thank you for contributing to LangChain-IBM!
Your time and effort help make the ecosystem stronger.
-->

## 📝 Description

**Related Issue:** <!-- Add issue link or reference here -->

### 💡 Summary of Changes
<!-- Briefly describe what this PR changes and why -->

We use the following code of `cursor.executemany(SQL_INSERT, docs)` so we can do the bulk insert to improve the performance. Rather than execute insert query one by one.

```
        embeddingLen = self.get_embedding_dimension()
        docs: List[Tuple[Any, Any, Any, Any]]
        docs = [
            (id_, f"{embedding}", json.dumps(metadata), text)
            for id_, embedding, metadata, text in zip(
                processed_ids, embeddings, metadatas, texts
            )
        ]

        SQL_INSERT = (
            f"INSERT INTO {self.table_name} (id, embedding, metadata, text) "
            f"VALUES (?, VECTOR(?, {embeddingLen}, FLOAT32), SYSTOOLS.JSON2BSON(?), ?)"
        )

        print(docs)
        print(SQL_INSERT)

        cursor = self.client.cursor()
        try:
            cursor.executemany(SQL_INSERT, docs)
            cursor.execute("COMMIT")
```
The embedding in the docs is passed as a long string like below:
```
[('4AABEDBE2C6B098E', '[-0.02809087000787258, 0.0013685045996680856, -0.019762959331274033, 0.008430182933807373, 0.019694777205586433, -0.00436850031837821, -0.03925319015979767, 0.04398695006966591, -0.026649313047528267, 0.02809087000787258, 0.02464282140135765, 0.022499967366456985, 0.0326298251748085, -0.0686102956533432, -0.03541553393006325, 0.05922069400548935, -0.02253892831504345, 0.03642851859331131, -0.009365246631205082, -0.011571411974728107, 
...... (here we omit total 1536 float32 values) ......
 -0.031324632465839386, 0.03144151344895363, 0.02497399039566517, -0.011376607231795788, -0.001265014405362308, -0.02125321701169014, 0.0017922052647918463, -0.0064236922189593315]', '{"filename": "TEST FILE (1).txt", "file_size": 228, "mimetype": "text/plain", "files": [], "sender": null, "sender_name": null, "session_id": "", "timestamp": "2025-10-18 00:47:05 UTC", "flow_id": "d446f897-4579-4182-ad1e-b60497163288", "error": false, "edit": false, "properties": {"text_color": null, "background_color": null, "edited": false, "source": {"id": null, "display_name": null, "source": null}, "icon": null, "allow_markdown": false, "positive_feedback": null, "state": "complete", "targets": []}, "category": "message", "content_blocks": [], "duration": null}', 'Vector Storage and Functions for in-db Vector Similarity Search: Externals\nTable of Contents\nInformation\nAuthor(s)\nPlan\nAssociated Epics and/or Issues/Stories\nDeadlines\nPlanning meeting notes\nDesign\nProblem to solve')]
```
The SQL_INSERT here is:
```
INSERT INTO table15 (id, embedding, metadata, text) VALUES (?, VECTOR(?, 1536, FLOAT32), SYSTOOLS.JSON2BSON(?), ?)
```

However, I noticed if the embedding_dimension is large, for example, if it is 1536 like the case above, we will hit error:
```
Exception: Error 1: [IBM][CLI Driver][DB2/LINUXX8664] SQL0302N  The value of a host variable in the EXECUTE or OPEN statement is out of range for its corresponding use.  SQLSTATE=22001  SQLCODE=-302
```

If the embedding_dimension is relative small, everything is good and we will not hit that issue, e.g. if it is 500
```
INSERT INTO table15 (id, embedding, metadata, text) VALUES (?, VECTOR(?, 500, FLOAT32), SYSTOOLS.JSON2BSON(?), ?)
```

The parameter marker for VECTOR(?, 1536, FLOAT32) is described as a VARCHAR(24577), but the string we are passing is much larger (>32k, so it is CLOB size). Your float values have a much larger precision than is supported by FLOAT32, so the string is very long. The solution here is to override the default parameter marker description type by changing the insert query.

## ✅ PR Checklist

- [x] **PR Title Format:** `{TYPE}({SCOPE}): {DESCRIPTION}`
  - **Examples:**
    - feat(langchain-ibm): add multi-tenant support  
    - fix(langchain-db2): resolve flag parsing error  
    - docs(langchain-ibm): update API usage examples  
  - **Allowed `{TYPE}` values:**  
    `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`, `release`
  - **Allowed `{SCOPE}` values (optional):**  
    `langchain-ibm`, `langchain-db2`

- [x] **PR Description:** The *Description* section clearly lists what was changed, why, and how it was tested.

- [x] **Formatting, Linting & Tests**  
  Run the following commands from the root of the modified package(s):
  ```bash
  make format
  make lint
  make test
  ```
  ⚠️ PRs will only be considered if all checks pass in CI.  
  See the [contribution guidelines](https://docs.langchain.com/oss/python/contributing) for more details.

---

## 🧪 Testing (optional)

<!-- Describe how you tested your changes and include any relevant outputs -->

---

## 🗒️ Notes (optional)

<!-- Add any additional context, known issues, or follow-up tasks -->


Thank you again for helping improve **LangChain-IBM**! 🚀  
Your contribution makes the project better for everyone.
