### PR TITLE
fix(langchain-ibm): Fix passing scope env variables in WatsonxSQLDatabase

### DIFF
--- a/libs/ibm/langchain_ibm/utilities/sql_database.py
+++ b/libs/ibm/langchain_ibm/utilities/sql_database.py
@@ -392,8 +392,6 @@ class WatsonxSQLDatabase:
             )
             self.watsonx_client = APIClient(
                 credentials=credentials,
-                project_id=project_id,
-                space_id=space_id,
             )
             if project_id:
                 self.watsonx_client.set.default_project(project_id=project_id)

--- a/libs/ibm/pyproject.toml
+++ b/libs/ibm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "pdm.backend"
 
 [project]
 name = "langchain-ibm"
-version = "1.0.8"
+version = "1.0.9"
 description = "An integration package connecting IBM watsonx.ai and LangChain"
 authors = [{ name = "IBM" }]
 license = { text = "MIT" }

--- a/libs/ibm/tests/unit_tests/utilities/test_sql_database.py
+++ b/libs/ibm/tests/unit_tests/utilities/test_sql_database.py
@@ -641,11 +641,13 @@ def test_initialize_watsonx_sql_database_with_project_id_env(
 
         wx_sql_database = WatsonxSQLDatabase(connection_id=CONNECTION_ID, schema=schema)
 
-        # Verify APIClient was called with project_id from environment
         mock_client.assert_called_once()
         call_kwargs = mock_client.call_args[1]
-        assert call_kwargs["project_id"] == PROJECT_ID
-        assert call_kwargs["space_id"] is None
+        assert "credentials" in call_kwargs
+        # Verify set.default_project was called with project_id from environment
+        mock_api_client.set.default_project.assert_called_once_with(
+            project_id=PROJECT_ID
+        )
         assert isinstance(wx_sql_database._flight_sql_client, MockFlightSQLClient)
         assert wx_sql_database.schema == schema
 
@@ -682,11 +684,11 @@ def test_initialize_watsonx_sql_database_with_space_id_env(
 
         wx_sql_database = WatsonxSQLDatabase(connection_id=CONNECTION_ID, schema=schema)
 
-        # Verify APIClient was called with space_id from environment
         mock_client.assert_called_once()
         call_kwargs = mock_client.call_args[1]
-        assert call_kwargs["project_id"] is None
-        assert call_kwargs["space_id"] == space_id
+        assert "credentials" in call_kwargs
+        # Verify set.default_space was called with space_id from environment
+        mock_api_client.set.default_space.assert_called_once_with(space_id=space_id)
         assert isinstance(wx_sql_database._flight_sql_client, MockFlightSQLClient)
         assert wx_sql_database.schema == schema
 
@@ -726,11 +728,12 @@ def test_initialize_watsonx_sql_database_param_overrides_env(
             connection_id=CONNECTION_ID, schema=schema, project_id=param_project_id
         )
 
-        # Verify APIClient was called with project_id from parameter, not environment
         mock_client.assert_called_once()
         call_kwargs = mock_client.call_args[1]
-        assert call_kwargs["project_id"] == param_project_id
-        assert call_kwargs["space_id"] is None
+        assert "credentials" in call_kwargs
+        mock_api_client.set.default_project.assert_called_once_with(
+            project_id=param_project_id
+        )
         assert isinstance(wx_sql_database._flight_sql_client, MockFlightSQLClient)
         assert wx_sql_database.schema == schema
 

--- a/libs/ibm/uv.lock
+++ b/libs/ibm/uv.lock
@@ -515,7 +515,7 @@ wheels = [
 
 [[package]]
 name = "langchain-ibm"
-version = "1.0.8"
+version = "1.0.9"
 source = { editable = "." }
 dependencies = [
     { name = "ibm-watsonx-ai", version = "1.3.42", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
<!--
🙏 Thank you for contributing to LangChain-IBM!
Your time and effort help make the ecosystem stronger.
-->

## 📝 Description

**Related Issue:** <!-- Add issue link or reference here -->

### 💡 Summary of Changes
<!-- Briefly describe what this PR changes and why -->

- Fix passing scope env variables in WatsonxSQLDatabase

---

## ✅ PR Checklist

- [x] **PR Title Format:** `{TYPE}({SCOPE}): {DESCRIPTION}`
  - **Examples:**
    - feat(langchain-ibm): add multi-tenant support  
    - fix(langchain-db2): resolve flag parsing error  
    - docs(langchain-ibm): update API usage examples  
  - **Allowed `{TYPE}` values:**  
    `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`, `release`
  - **Allowed `{SCOPE}` values (optional):**  
    `langchain-ibm`, `langchain-db2`

- [x] **PR Description:** The *Description* section clearly lists what was changed, why, and how it was tested.

- [x] **Formatting, Linting & Tests**  
  Run the following commands from the root of the modified package(s):
  ```bash
  make format
  make lint
  make test
  ```
  ⚠️ PRs will only be considered if all checks pass in CI.  
  See the [contribution guidelines](https://docs.langchain.com/oss/python/contributing) for more details.

---

## 🧪 Testing (optional)

<!-- Describe how you tested your changes and include any relevant outputs -->

---

## 🗒️ Notes (optional)

<!-- Add any additional context, known issues, or follow-up tasks -->


Thank you again for helping improve **LangChain-IBM**! 🚀  
Your contribution makes the project better for everyone.
