### PR TITLE
chore(langchain_ibm): Add error message when no scope provided with `model_id`

### DIFF
--- a/libs/ibm/langchain_ibm/chat_models.py
+++ b/libs/ibm/langchain_ibm/chat_models.py
@@ -95,6 +95,7 @@ from langchain_ibm.utils import (
     normalize_tool_arguments,
     resolve_watsonx_credentials,
     secret_from_env_multi,
+    validate_scope_with_model_id,
 )
 
 if TYPE_CHECKING:
@@ -1133,6 +1134,7 @@ class ChatWatsonx(BaseChatModel):
                     "parameters when initializing ChatWatsonx.",
                 )
                 raise ValueError(error_msg)
+
             if self.model is not None:
                 watsonx_model_gateway = Gateway(
                     api_client=self.watsonx_client,
@@ -1170,6 +1172,12 @@ class ChatWatsonx(BaseChatModel):
                 version=self.version,
                 verify=self.verify,
             )
+
+            # Validate that project_id or space_id is provided when using model_id
+            validate_scope_with_model_id(
+                self.model_id, self.project_id, self.space_id, self.__class__.__name__
+            )
+
             if self.model is not None:
                 watsonx_model_gateway = Gateway(
                     credentials=credentials,

--- a/libs/ibm/langchain_ibm/embeddings.py
+++ b/libs/ibm/langchain_ibm/embeddings.py
@@ -27,6 +27,7 @@ from langchain_ibm.utils import (
     normalize_api_key,
     resolve_watsonx_credentials,
     secret_from_env_multi,
+    validate_scope_with_model_id,
 )
 
 logger = logging.getLogger(__name__)
@@ -277,6 +278,12 @@ class WatsonxEmbeddings(BaseModel, LangChainEmbeddings):
                 version=self.version,
                 verify=self.verify,
             )
+
+            # Validate that project_id or space_id is provided when using model_id
+            validate_scope_with_model_id(
+                self.model_id, self.project_id, self.space_id, self.__class__.__name__
+            )
+
             if self.model is not None:
                 watsonx_embed_gateway = Gateway(
                     credentials=credentials,

--- a/libs/ibm/langchain_ibm/llms.py
+++ b/libs/ibm/langchain_ibm/llms.py
@@ -28,6 +28,7 @@ from langchain_ibm.utils import (
     normalize_api_key,
     resolve_watsonx_credentials,
     secret_from_env_multi,
+    validate_scope_with_model_id,
 )
 
 if TYPE_CHECKING:
@@ -336,6 +337,12 @@ class WatsonxLLM(BaseLLM):
                 version=self.version,
                 verify=self.verify,
             )
+
+            # Validate that project_id or space_id is provided when using model_id
+            validate_scope_with_model_id(
+                self.model_id, self.project_id, self.space_id, self.__class__.__name__
+            )
+
             if self.model is not None:
                 watsonx_model_gateway = Gateway(
                     credentials=credentials,

--- a/libs/ibm/langchain_ibm/rerank.py
+++ b/libs/ibm/langchain_ibm/rerank.py
@@ -19,6 +19,7 @@ from langchain_ibm.utils import (
     normalize_api_key,
     resolve_watsonx_credentials,
     secret_from_env_multi,
+    validate_scope_with_model_id,
 )
 
 if TYPE_CHECKING:
@@ -224,6 +225,11 @@ class WatsonxRerank(BaseDocumentCompressor):
                 instance_id=self.instance_id,
                 version=self.version,
                 verify=self.verify,
+            )
+
+            # Validate that project_id or space_id is provided when using model_id
+            validate_scope_with_model_id(
+                self.model_id, self.project_id, self.space_id, self.__class__.__name__
             )
 
             watsonx_rerank = Rerank(

--- a/libs/ibm/langchain_ibm/utils.py
+++ b/libs/ibm/langchain_ibm/utils.py
@@ -350,3 +350,30 @@ def normalize_tool_arguments(args_str: str) -> str:
             return "{}"
 
     return json.dumps(parsed_object, ensure_ascii=False)
+
+
+def validate_scope_with_model_id(
+    model_id: str | None,
+    project_id: str | None,
+    space_id: str | None,
+    class_name: str,
+) -> None:
+    """Validate that scope (project_id or space_id) is provided when using model_id.
+
+    Args:
+        model_id: The model ID being used
+        project_id: The project ID
+        space_id: The space ID
+        class_name: Name of the class for error message (e.g., 'ChatWatsonx')
+
+    Raises:
+        ValueError: If model_id is provided but neither project_id nor space_id is set
+    """
+    if model_id is not None and not project_id and not space_id:
+        error_msg = (
+            f"When using 'model_id', you must provide either 'project_id' "
+            f"or 'space_id'. These can be passed as parameters to {class_name}"
+            " or set as environment variables 'WATSONX_PROJECT_ID' or "
+            "'WATSONX_SPACE_ID'."
+        )
+        raise ValueError(error_msg)

--- a/libs/ibm/tests/unit_tests/test_chat_models.py
+++ b/libs/ibm/tests/unit_tests/test_chat_models.py
@@ -67,6 +67,7 @@ def test_initialize_chat_watsonx_with_deprecated_apikey() -> None:
     ):
         ChatWatsonx(
             model_id=MODEL_ID,
+            project_id="fake_project_id",
             url="https://us-south.ml.cloud.ibm.com",
             apikey="test_apikey",
         )
@@ -83,6 +84,7 @@ def test_initialize_chat_watsonx_with_api_key_and_apikey() -> None:
     ):
         ChatWatsonx(
             model_id=MODEL_ID,
+            project_id="fake_project_id",
             url="https://us-south.ml.cloud.ibm.com",
             apikey="fake_apikey",
             api_key="fake_api_key",
@@ -143,6 +145,7 @@ def test_initialize_chat_watsonx_cpd_deprecation_warning_with_instance_id() -> N
     ):
         ChatWatsonx(
             model_id="google/flan-ul2",
+            project_id="fake_project_id",
             url="https://cpd-zen.apps.cpd48.cp.fyre.ibm.com",
             apikey="test_apikey",
             username="test_user",
@@ -325,6 +328,7 @@ def test_initialize_chat_watsonx_with_all_supported_params_v2(mocker: Any) -> No
 
     chat = ChatWatsonx(
         model_id="google/flan-ul2",
+        project_id="fake_project_id",
         url="https://us-south.ml.cloud.ibm.com",
         apikey="test_apikey",
         frequency_penalty=0.5,
@@ -478,23 +482,23 @@ def test_initialize_chat_watsonx_explicit_space_id_overrides_env(
     assert chat.space_id == explicit_space_id
 
 
-def test_initialize_chat_watsonx_without_project_id_or_space_id_env(
-    mocker: Any, monkeypatch: pytest.MonkeyPatch
+def test_initialize_chat_watsonx_model_id_without_project_or_space_id(
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test that project_id and space_id default to None when not set."""
+    """Test that ValueError is raised when model_id is used without scope."""
     monkeypatch.delenv("WATSONX_PROJECT_ID", raising=False)
     monkeypatch.delenv("WATSONX_SPACE_ID", raising=False)
 
-    mocker.patch(
-        "ibm_watsonx_ai.foundation_models.ModelInference.__init__",
-        return_value=None,
+    error_pattern = re.escape(
+        "When using 'model_id', you must provide either 'project_id' "
+        "or 'space_id'. These can be passed as parameters to ChatWatsonx"
+        " or set as environment variables 'WATSONX_PROJECT_ID' or "
+        "'WATSONX_SPACE_ID'."
     )
 
-    chat = ChatWatsonx(
-        model_id=MODEL_ID,
-        url="https://us-south.ml.cloud.ibm.com",
-        apikey="test_apikey",
-    )
-
-    assert chat.project_id is None
-    assert chat.space_id is None
+    with pytest.raises(ValueError, match=error_pattern):
+        ChatWatsonx(
+            model_id=MODEL_ID,
+            url="https://us-south.ml.cloud.ibm.com",
+            apikey="test_apikey",
+        )

--- a/libs/ibm/tests/unit_tests/test_chat_models.py
+++ b/libs/ibm/tests/unit_tests/test_chat_models.py
@@ -256,6 +256,7 @@ def test_initialize_chat_watsonx_with_all_supported_params(mocker: Any) -> None:
 
     chat = ChatWatsonx(
         model_id="google/flan-ul2",
+        project_id="fake_project_id",
         url="https://us-south.ml.cloud.ibm.com",
         apikey="test_apikey",
         frequency_penalty=0.5,

--- a/libs/ibm/tests/unit_tests/test_embeddings.py
+++ b/libs/ibm/tests/unit_tests/test_embeddings.py
@@ -63,6 +63,7 @@ def test_initialize_watsonx_embeddings_with_deprecated_apikey() -> None:
     ):
         WatsonxEmbeddings(
             model_id=MODEL_ID,
+            project_id="fake_project_id",
             url="https://us-south.ml.cloud.ibm.com",
             apikey="test_apikey",
         )
@@ -79,6 +80,7 @@ def test_initialize_watsonx_embeddings_with_api_key_and_apikey() -> None:
     ):
         WatsonxEmbeddings(
             model_id=MODEL_ID,
+            project_id="fake_project_id",
             url="https://us-south.ml.cloud.ibm.com",
             apikey="fake_apikey",
             api_key="fake_api_key",
@@ -128,6 +130,7 @@ def test_initialize_watsonx_embeddings_cpd_deprecation_warning_with_instance_id(
     ):
         WatsonxEmbeddings(
             model_id="google/flan-ul2",
+            project_id="fake_project_id",
             url="https://cpd-zen.apps.cpd48.cp.fyre.ibm.com",
             apikey="test_apikey",
             username="test_user",
@@ -297,23 +300,23 @@ def test_initialize_watsonx_embeddings_explicit_space_id_overrides_env(
     assert embeddings.space_id == explicit_space_id
 
 
-def test_initialize_watsonx_embeddings_without_project_id_or_space_id_env(
-    mocker: Any, monkeypatch: pytest.MonkeyPatch
+def test_initialize_watsonx_embeddings_model_id_without_project_or_space_id(
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test that project_id and space_id default to None when not set."""
+    """Test that ValueError is raised when model_id is used without scope."""
     monkeypatch.delenv("WATSONX_PROJECT_ID", raising=False)
     monkeypatch.delenv("WATSONX_SPACE_ID", raising=False)
 
-    mocker.patch(
-        "ibm_watsonx_ai.foundation_models.Embeddings.__init__",
-        return_value=None,
+    error_pattern = re.escape(
+        "When using 'model_id', you must provide either 'project_id' "
+        "or 'space_id'. These can be passed as parameters to WatsonxEmbeddings"
+        " or set as environment variables 'WATSONX_PROJECT_ID' or "
+        "'WATSONX_SPACE_ID'."
     )
 
-    embeddings = WatsonxEmbeddings(
-        model_id=MODEL_ID,
-        url="https://us-south.ml.cloud.ibm.com",
-        apikey="test_apikey",
-    )
-
-    assert embeddings.project_id is None
-    assert embeddings.space_id is None
+    with pytest.raises(ValueError, match=error_pattern):
+        WatsonxEmbeddings(
+            model_id=MODEL_ID,
+            url="https://us-south.ml.cloud.ibm.com",
+            apikey="test_apikey",
+        )

--- a/libs/ibm/tests/unit_tests/test_llms.py
+++ b/libs/ibm/tests/unit_tests/test_llms.py
@@ -69,6 +69,7 @@ def test_initialize_watsonxllm_with_deprecated_apikey() -> None:
     ):
         WatsonxLLM(
             model_id=MODEL_ID,
+            project_id="fake_project_id",
             url="https://us-south.ml.cloud.ibm.com",
             apikey="test_apikey",
         )
@@ -85,6 +86,7 @@ def test_initialize_watsonxllm_with_api_key_and_apikey() -> None:
     ):
         WatsonxLLM(
             model_id=MODEL_ID,
+            project_id="fake_project_id",
             url="https://us-south.ml.cloud.ibm.com",
             apikey="fake_apikey",
             api_key="fake_api_key",
@@ -132,6 +134,7 @@ def test_initialize_watsonxllm_cpd_deprecation_warning_with_instance_id() -> Non
     ):
         WatsonxLLM(
             model_id="google/flan-ul2",
+            project_id="fake_project_id",
             url="https://cpd-zen.apps.cpd48.cp.fyre.ibm.com",
             apikey="test_apikey",
             username="test_user",
@@ -321,23 +324,23 @@ def test_initialize_watsonxllm_explicit_space_id_overrides_env(
     assert chat.space_id == explicit_space_id
 
 
-def test_initialize_watsonxllm_without_project_id_or_space_id_env(
-    mocker: Any, monkeypatch: pytest.MonkeyPatch
+def test_initialize_watsonxllm_model_id_without_project_or_space_id(
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test that project_id and space_id default to None when not set."""
+    """Test that ValueError is raised when model_id is used without scope."""
     monkeypatch.delenv("WATSONX_PROJECT_ID", raising=False)
     monkeypatch.delenv("WATSONX_SPACE_ID", raising=False)
 
-    mocker.patch(
-        "ibm_watsonx_ai.foundation_models.ModelInference.__init__",
-        return_value=None,
+    error_pattern = re.escape(
+        "When using 'model_id', you must provide either 'project_id' "
+        "or 'space_id'. These can be passed as parameters to WatsonxLLM"
+        " or set as environment variables 'WATSONX_PROJECT_ID' or "
+        "'WATSONX_SPACE_ID'."
     )
 
-    chat = WatsonxLLM(
-        model_id=MODEL_ID,
-        url="https://us-south.ml.cloud.ibm.com",
-        apikey="test_apikey",
-    )
-
-    assert chat.project_id is None
-    assert chat.space_id is None
+    with pytest.raises(ValueError, match=error_pattern):
+        WatsonxLLM(
+            model_id=MODEL_ID,
+            url="https://us-south.ml.cloud.ibm.com",
+            apikey="test_apikey",
+        )

--- a/libs/ibm/tests/unit_tests/test_rerank.py
+++ b/libs/ibm/tests/unit_tests/test_rerank.py
@@ -1,6 +1,7 @@
 """Test WatsonxRerank API wrapper."""
 
 import os
+import re
 from typing import Any
 
 import pytest
@@ -44,6 +45,7 @@ def test_initialize_watsonx_rerank_with_deprecated_apikey() -> None:
     ):
         WatsonxRerank(
             model_id=MODEL_ID,
+            project_id="fake_project_id",
             url="https://us-south.ml.cloud.ibm.com",
             apikey="test_apikey",
         )
@@ -60,6 +62,7 @@ def test_initialize_watsonx_rerank_with_api_key_and_apikey() -> None:
     ):
         WatsonxRerank(
             model_id=MODEL_ID,
+            project_id="fake_project_id",
             url="https://us-south.ml.cloud.ibm.com",
             apikey="fake_apikey",
             api_key="fake_api_key",
@@ -107,6 +110,7 @@ def test_initialize_watsonx_rerank_cpd_deprecation_warning_with_instance_id() ->
     ):
         WatsonxRerank(
             model_id=MODEL_ID,
+            project_id="fake_project_id",
             url="https://cpd-zen.apps.cpd48.cp.fyre.ibm.com",
             apikey="test_apikey",
             username="test_user",
@@ -226,23 +230,23 @@ def test_initialize_watsonx_rerank_explicit_space_id_overrides_env(
     assert rerank.space_id == explicit_space_id
 
 
-def test_initialize_watsonx_rerank_without_project_id_or_space_id_env(
-    mocker: Any, monkeypatch: pytest.MonkeyPatch
+def test_initialize_watsonx_rerank_model_id_without_project_or_space_id(
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test that project_id and space_id default to None when not set."""
+    """Test that ValueError is raised when model_id is used without scope."""
     monkeypatch.delenv("WATSONX_PROJECT_ID", raising=False)
     monkeypatch.delenv("WATSONX_SPACE_ID", raising=False)
 
-    mocker.patch(
-        "ibm_watsonx_ai.foundation_models.Rerank.__init__",
-        return_value=None,
+    error_pattern = re.escape(
+        "When using 'model_id', you must provide either 'project_id' "
+        "or 'space_id'. These can be passed as parameters to WatsonxRerank"
+        " or set as environment variables 'WATSONX_PROJECT_ID' or "
+        "'WATSONX_SPACE_ID'."
     )
 
-    rerank = WatsonxRerank(
-        model_id=MODEL_ID,
-        url="https://us-south.ml.cloud.ibm.com",
-        apikey="test_apikey",
-    )
-
-    assert rerank.project_id is None
-    assert rerank.space_id is None
+    with pytest.raises(ValueError, match=error_pattern):
+        WatsonxRerank(
+            model_id=MODEL_ID,
+            url="https://us-south.ml.cloud.ibm.com",
+            apikey="test_apikey",
+        )


### PR DESCRIPTION
<!--
🙏 Thank you for contributing to LangChain-IBM!
Your time and effort help make the ecosystem stronger.
-->

## 📝 Description

**Related Issue:** <!-- Add issue link or reference here -->

### 💡 Summary of Changes
<!-- Briefly describe what this PR changes and why -->

- Add error message when no scope provided with `model_id`

When user trying to invoke chat without precising scope, then uninformed error is shown, we would like to extend this error for more user-friendly information

---

## ✅ PR Checklist

- [x] **PR Title Format:** `{TYPE}({SCOPE}): {DESCRIPTION}`
  - **Examples:**
    - feat(langchain-ibm): add multi-tenant support  
    - fix(langchain-db2): resolve flag parsing error  
    - docs(langchain-ibm): update API usage examples  
  - **Allowed `{TYPE}` values:**  
    `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`, `release`
  - **Allowed `{SCOPE}` values (optional):**  
    `langchain-ibm`, `langchain-db2`

- [x] **PR Description:** The *Description* section clearly lists what was changed, why, and how it was tested.

- [x] **Formatting, Linting & Tests**  
  Run the following commands from the root of the modified package(s):
  ```bash
  make format
  make lint
  make test
  ```
  ⚠️ PRs will only be considered if all checks pass in CI.  
  See the [contribution guidelines](https://docs.langchain.com/oss/python/contributing) for more details.

---

## 🧪 Testing (optional)

<!-- Describe how you tested your changes and include any relevant outputs -->

---

## 🗒️ Notes (optional)

<!-- Add any additional context, known issues, or follow-up tasks -->


Thank you again for helping improve **LangChain-IBM**! 🚀  
Your contribution makes the project better for everyone.
