### PR TITLE
feat: add metadata query parallelization

### DIFF
--- a/libs/ibm/langchain_ibm/utilities/sql_database.py
+++ b/libs/ibm/langchain_ibm/utilities/sql_database.py
@@ -4,6 +4,7 @@ import contextlib
 import urllib.parse
 from collections import Counter
 from collections.abc import Iterable
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Literal
 
 try:
@@ -234,6 +235,7 @@ class WatsonxSQLDatabase:
         include_tables: list of tables that should be included
         sample_rows_in_table_info: number of first rows to be added to the table info
         max_string_length: max length of string
+        max_workers: max number of worker threads
 
 
     ???+ info "Setup"
@@ -298,6 +300,7 @@ class WatsonxSQLDatabase:
         include_tables: list[str] | None = None,
         sample_rows_in_table_info: int = 3,
         max_string_length: int = 300,
+        max_workers: int | None = 1,
     ) -> None:
         """WatsonxSQLDatabase class."""
         if include_tables and ignore_tables:
@@ -310,6 +313,8 @@ class WatsonxSQLDatabase:
         self._sample_rows_in_table_info = sample_rows_in_table_info
 
         self._max_string_length = max_string_length
+
+        self._max_workers = max_workers
 
         if watsonx_client is None:
             url = url or _from_env("WATSONX_URL")
@@ -448,18 +453,35 @@ class WatsonxSQLDatabase:
                     error_msg = f"ignore_tables {missing_tables} not found in database"
                     raise ValueError(error_msg)
 
-            self._meta_all_tables = {
-                table_name: flight_sql_client.get_table_info(
-                    table_name=table_name,
-                    schema=self.schema,
-                    extended_metadata=True,
-                    interaction_properties=True,
-                )
-                | {"description": _table_descriptions.get(table_name)}
+            tables_to_fetch = {
+                table_name
                 for table_name in self._all_tables
                 if table_name in (self._include_tables or self._all_tables)
                 and table_name not in (self._ignore_tables or {})
             }
+
+            def fetch_table_metadata(table_name: str) -> tuple[str, dict[str, Any]]:
+                """Fetch metadata for a single table."""
+                return (
+                    table_name,
+                    flight_sql_client.get_table_info(
+                        table_name=table_name,
+                        schema=self.schema,
+                        extended_metadata=True,
+                        interaction_properties=True,
+                    ),
+                )
+
+            self._meta_all_tables = {}
+            with ThreadPoolExecutor(max_workers=self._max_workers) as executor:
+                future_to_table = {
+                    executor.submit(fetch_table_metadata, table_name): table_name
+                    for table_name in tables_to_fetch
+                }
+
+                for future in as_completed(future_to_table):
+                    table_name, metadata = future.result()
+                    self._meta_all_tables[table_name] = metadata
 
     def get_usable_table_names(self) -> Iterable[str]:
         """Get names of tables available."""
@@ -576,7 +598,8 @@ class WatsonxSQLDatabase:
             if table_names is None:
                 table_names = self._all_tables
 
-            def convert_rows(table_name: str) -> str:
+            def fetch_sample_rows(table_name: str) -> tuple[str, str]:
+                """Fetch sample rows for a single table."""
                 rows = flight_sql_client.get_n_first_rows(
                     schema=self.schema,
                     table_name=table_name,
@@ -584,14 +607,27 @@ class WatsonxSQLDatabase:
                 )
                 match fmt:
                     case "ddl":
-                        return str(rows.to_string(index=False) or "")
+                        rows_str = str(rows.to_string(index=False) or "")
                     case "markdown":
-                        return str(
+                        rows_str = str(
                             rows.to_markdown(index=False, tablefmt="github") or ""
                         )
+                    case _:
+                        err_msg = f"Format '{fmt}' is not supported"  # type: ignore[unreachable]
+                        raise ValueError(err_msg)
 
-                err_msg = f"Format '{fmt}' is not supported"  # type: ignore[unreachable]
-                raise ValueError(err_msg)
+                return table_name, rows_str
+
+            table_rows = {}
+            with ThreadPoolExecutor(max_workers=self._max_workers) as executor:
+                future_to_table = {
+                    executor.submit(fetch_sample_rows, table_name): table_name
+                    for table_name in table_names
+                }
+
+                for future in as_completed(future_to_table):
+                    table_name, rows_str = future.result()
+                    table_rows[table_name] = rows_str
 
             return "\n\n".join(
                 [
@@ -604,7 +640,7 @@ class WatsonxSQLDatabase:
                         ),
                         rows_number=self._sample_rows_in_table_info,
                         table_name=table_name,
-                        rows=convert_rows(table_name=table_name),
+                        rows=table_rows[table_name],
                     )
                     for table_name in table_names
                 ],

--- a/libs/ibm/langchain_ibm/utilities/sql_database.py
+++ b/libs/ibm/langchain_ibm/utilities/sql_database.py
@@ -235,7 +235,7 @@ class WatsonxSQLDatabase:
         include_tables: list of tables that should be included
         sample_rows_in_table_info: number of first rows to be added to the table info
         max_string_length: max length of string
-        max_workers: max number of worker threads
+        max_workers: max number of worker threads. None will base it on the number of processors
 
 
     ???+ info "Setup"

--- a/libs/ibm/langchain_ibm/utilities/sql_database.py
+++ b/libs/ibm/langchain_ibm/utilities/sql_database.py
@@ -235,7 +235,7 @@ class WatsonxSQLDatabase:
         include_tables: list of tables that should be included
         sample_rows_in_table_info: number of first rows to be added to the table info
         max_string_length: max length of string
-        max_workers: max number of worker threads. None will base it on the number of processors
+        max_workers: max number of threads. None will base it on the number of CPUs
 
 
     ???+ info "Setup"

--- a/libs/ibm/tests/unit_tests/utilities/test_sql_database.py
+++ b/libs/ibm/tests/unit_tests/utilities/test_sql_database.py
@@ -1169,8 +1169,11 @@ def test_execute_with_many_duplicate_columns(
         assert result == expected
 
 
+@pytest.mark.parametrize("max_workers", [1, None, 4])
 def test_parallel_fetching_table_metadata(
-    schema: str, monkeypatch: pytest.MonkeyPatch
+    schema: str,
+    monkeypatch: pytest.MonkeyPatch,
+    max_workers: int | None,
 ) -> None:
     """Test that table metadata is fetched in parallel using ThreadPoolExecutor."""
 
@@ -1220,13 +1223,13 @@ def test_parallel_fetching_table_metadata(
         for k, v in envvars.items():
             monkeypatch.setenv(k, v)
 
-        # Create database with max_workers=2
+        # Create database with max_workers
         wx_sql_database = WatsonxSQLDatabase(
-            connection_id=CONNECTION_ID, schema=schema, max_workers=2
+            connection_id=CONNECTION_ID, schema=schema, max_workers=max_workers
         )
 
         # Verify ThreadPoolExecutor was called with max_workers=2
-        assert executor_max_workers == 2
+        assert executor_max_workers == max_workers
 
         # Verify both tables were fetched
         assert "table1" in call_order
@@ -1235,8 +1238,11 @@ def test_parallel_fetching_table_metadata(
         assert len(wx_sql_database._meta_all_tables) == 2
 
 
+@pytest.mark.parametrize("max_workers", [1, None, 4])
 def test_parallel_fetching_sample_rows(
-    schema: str, monkeypatch: pytest.MonkeyPatch
+    schema: str,
+    monkeypatch: pytest.MonkeyPatch,
+    max_workers: int | None,
 ) -> None:
     """Test that sample rows are fetched in parallel using ThreadPoolExecutor."""
 
@@ -1283,9 +1289,9 @@ def test_parallel_fetching_sample_rows(
         for k, v in envvars.items():
             monkeypatch.setenv(k, v)
 
-        # Create database with max_workers=3
+        # Create database with max_workers
         wx_sql_database = WatsonxSQLDatabase(
-            connection_id=CONNECTION_ID, schema=schema, max_workers=3
+            connection_id=CONNECTION_ID, schema=schema, max_workers=max_workers
         )
 
         # Clear tracking for get_table_info call
@@ -1295,8 +1301,8 @@ def test_parallel_fetching_sample_rows(
         # Call get_table_info which should fetch sample rows in parallel
         wx_sql_database.get_table_info(["table1", "table2"])
 
-        # Verify ThreadPoolExecutor was called with max_workers=3 for sample rows
-        assert 3 in executor_calls
+        # Verify ThreadPoolExecutor was called with max_workers for sample rows
+        assert max_workers in executor_calls
 
         # Verify sample rows were fetched for both tables
         assert "table1" in sample_rows_calls

--- a/libs/ibm/tests/unit_tests/utilities/test_sql_database.py
+++ b/libs/ibm/tests/unit_tests/utilities/test_sql_database.py
@@ -1,5 +1,6 @@
 import os
 from collections.abc import Generator
+from concurrent.futures import ThreadPoolExecutor as RealThreadPoolExecutor
 from typing import Any
 from unittest import mock
 from unittest.mock import Mock, patch
@@ -1166,3 +1167,137 @@ def test_execute_with_many_duplicate_columns(
             "'count_3': 1000, 'sum_3': 19678, 'count_4': 1000, 'sum_4': 19678}]"
         )
         assert result == expected
+
+
+def test_parallel_fetching_table_metadata(
+    schema: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test that table metadata is fetched in parallel using ThreadPoolExecutor."""
+
+    mock_api_client = Mock()
+    mock_api_client.default_project_id = PROJECT_ID
+
+    # Track the order and timing of get_table_info calls
+    call_order = []
+    executor_max_workers = None
+
+    class MockFlightSQLClientParallel(MockFlightSQLClient):
+        def get_table_info(
+            self, table_name: str, *_args: Any, **_kwargs: Any
+        ) -> dict[str, Any]:
+            call_order.append(table_name)
+            return super().get_table_info(table_name, *_args, **_kwargs)
+
+    # Create a wrapper that captures max_workers but uses real ThreadPoolExecutor
+    original_executor = RealThreadPoolExecutor
+
+    def executor_wrapper(*args: Any, **kwargs: Any) -> RealThreadPoolExecutor:
+        nonlocal executor_max_workers
+        executor_max_workers = kwargs.get("max_workers")
+        return original_executor(*args, **kwargs)
+
+    with (
+        mock.patch.dict(os.environ, clear=True),
+        patch(
+            "langchain_ibm.utilities.sql_database.APIClient",
+            autospec=True,
+            return_value=mock_api_client,
+        ),
+        patch(
+            "langchain_ibm.utilities.sql_database.FlightSQLClient",
+            autospec=True,
+            return_value=MockFlightSQLClientParallel(),
+        ),
+        patch(
+            "langchain_ibm.utilities.sql_database.ThreadPoolExecutor",
+            side_effect=executor_wrapper,
+        ),
+    ):
+        envvars = {
+            "WATSONX_APIKEY": "test_apikey",
+            "WATSONX_URL": "https://us-south.ml.cloud.ibm.com",
+        }
+        for k, v in envvars.items():
+            monkeypatch.setenv(k, v)
+
+        # Create database with max_workers=2
+        wx_sql_database = WatsonxSQLDatabase(
+            connection_id=CONNECTION_ID, schema=schema, max_workers=2
+        )
+
+        # Verify ThreadPoolExecutor was called with max_workers=2
+        assert executor_max_workers == 2
+
+        # Verify both tables were fetched
+        assert "table1" in call_order
+        assert "table2" in call_order
+        assert wx_sql_database._meta_all_tables is not None
+        assert len(wx_sql_database._meta_all_tables) == 2
+
+
+def test_parallel_fetching_sample_rows(
+    schema: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test that sample rows are fetched in parallel using ThreadPoolExecutor."""
+
+    mock_api_client = Mock()
+    mock_api_client.default_project_id = PROJECT_ID
+
+    # Track calls to get_n_first_rows
+    sample_rows_calls = []
+    executor_calls = []
+
+    class MockFlightSQLClientParallelRows(MockFlightSQLClient):
+        def get_n_first_rows(self, *_args: Any, **kwargs: Any) -> pd.DataFrame:
+            sample_rows_calls.append(kwargs.get("table_name"))
+            return super().get_n_first_rows(*_args, **kwargs)
+
+    # Create a wrapper that captures max_workers but uses real ThreadPoolExecutor
+    original_executor = RealThreadPoolExecutor
+
+    def executor_wrapper(*args: Any, **kwargs: Any) -> RealThreadPoolExecutor:
+        executor_calls.append(kwargs.get("max_workers"))
+        return original_executor(*args, **kwargs)
+
+    with (
+        mock.patch.dict(os.environ, clear=True),
+        patch(
+            "langchain_ibm.utilities.sql_database.APIClient",
+            autospec=True,
+            return_value=mock_api_client,
+        ),
+        patch(
+            "langchain_ibm.utilities.sql_database.FlightSQLClient",
+            autospec=True,
+            return_value=MockFlightSQLClientParallelRows(),
+        ),
+        patch(
+            "langchain_ibm.utilities.sql_database.ThreadPoolExecutor",
+            side_effect=executor_wrapper,
+        ),
+    ):
+        envvars = {
+            "WATSONX_APIKEY": "test_apikey",
+            "WATSONX_URL": "https://us-south.ml.cloud.ibm.com",
+        }
+        for k, v in envvars.items():
+            monkeypatch.setenv(k, v)
+
+        # Create database with max_workers=3
+        wx_sql_database = WatsonxSQLDatabase(
+            connection_id=CONNECTION_ID, schema=schema, max_workers=3
+        )
+
+        # Clear tracking for get_table_info call
+        executor_calls.clear()
+        sample_rows_calls.clear()
+
+        # Call get_table_info which should fetch sample rows in parallel
+        wx_sql_database.get_table_info(["table1", "table2"])
+
+        # Verify ThreadPoolExecutor was called with max_workers=3 for sample rows
+        assert 3 in executor_calls
+
+        # Verify sample rows were fetched for both tables
+        assert "table1" in sample_rows_calls
+        assert "table2" in sample_rows_calls


### PR DESCRIPTION
<!--
🙏 Thank you for contributing to LangChain-IBM!
Your time and effort help make the ecosystem stronger.
-->

## 📝 Description

**Related Issue:** <!-- Add issue link or reference here -->
<https://ibm-watsonx.atlassian.net/browse/WXAI-6696>

### 💡 Summary of Changes
<!-- Briefly describe what this PR changes and why -->

This PR parallelizes the metadata queries. Before, they were performed sequentially over a list of tables, which for large databases could take a while. Our investigation had shown that this simple parallelization can speed up AutoAI RAG experiments.

-

---

## ✅ PR Checklist

- [x] **PR Title Format:** `{TYPE}({SCOPE}): {DESCRIPTION}`
  - **Examples:**
    - feat(langchain-ibm): add multi-tenant support  
    - fix(langchain-db2): resolve flag parsing error  
    - docs(langchain-ibm): update API usage examples  
  - **Allowed `{TYPE}` values:**  
    `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`, `release`
  - **Allowed `{SCOPE}` values (optional):**  
    `langchain-ibm`, `langchain-db2`

- [x] **PR Description:** The *Description* section clearly lists what was changed, why, and how it was tested.

- [x] **Formatting, Linting & Tests**  
  Run the following commands from the root of the modified package(s):

  ```bash
  make format
  make lint
  make test
  ```

  ⚠️ PRs will only be considered if all checks pass in CI.  
  See the [contribution guidelines](https://docs.langchain.com/oss/python/contributing) for more details.

---

## 🧪 Testing (optional)

<!-- Describe how you tested your changes and include any relevant outputs -->

- Added new unit tests.
- AutoAI RAG works as expected with this change.

---

## 🗒️ Notes (optional)

<!-- Add any additional context, known issues, or follow-up tasks -->

Thank you again for helping improve **LangChain-IBM**! 🚀  
Your contribution makes the project better for everyone.
