### PR TITLE
chore(deps): bump setuptools for CVE-2026-59890

### DIFF
--- a/libs/langchain-db2/poetry.lock
+++ b/libs/langchain-db2/poetry.lock
@@ -3565,14 +3565,14 @@ video = ["transformers[video]"]
 
 [[package]]
 name = "setuptools"
-version = "80.9.0"
+version = "83.0.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.9"
 groups = ["test"]
 files = [
-    {file = "setuptools-80.9.0-py3-none-any.whl", hash = "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922"},
-    {file = "setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c"},
+    {file = "setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3"},
+    {file = "setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef"},
 ]
 
 [package.extras]


### PR DESCRIPTION
## Summary
- Updates `setuptools` in `libs/langchain-db2/poetry.lock` from `80.9.0` to patched `83.0.0`
- Addresses GHSA-h35f-9h28-mq5c / CVE-2026-59890
- Scoped to the Dependabot alert in `libs/langchain-db2/poetry.lock`

## Validation
- `uv lock --project libs/langchain-db2 --locked`

## Notes
- `libs/langchain-db2/uv.lock` already had `setuptools==83.0.0`; this PR aligns the stale Poetry lock entry.
- A targeted `poetry update setuptools --directory libs/langchain-db2` was attempted under Socket Firewall, but PyPI access through Socket Firewall failed with an SSL/CA error. The final lock change is the equivalent narrow artifact/hash update for `setuptools==83.0.0`.