### PR TITLE
feat(langchain-db2): DiskANN vector index support — create_index(), drop_index(), tablespace param

### DIFF
--- a/libs/langchain-db2/langchain_db2/__init__.py
+++ b/libs/langchain-db2/langchain_db2/__init__.py
@@ -2,7 +2,7 @@
 
 from importlib import metadata
 
-from langchain_db2.db2vs import DB2VS
+from langchain_db2.db2vs import DB2VS, drop_index
 
 try:
     __version__ = metadata.version(__package__)
@@ -14,4 +14,5 @@ del metadata  # optional, avoids polluting the results of dir(__package__)
 __all__ = [
     "DB2VS",
     "__version__",
+    "drop_index",
 ]

--- a/libs/langchain-db2/langchain_db2/db2vs.py
+++ b/libs/langchain-db2/langchain_db2/db2vs.py
@@ -201,7 +201,7 @@ def drop_index(client: Connection, index_name: str) -> None:
 
         drop_index(
             client=db_client,  # ibm_db_dbi.Connection
-            index_name="HNSW_IDX1",
+            index_name="VIDX1",
         )
         ```
 
@@ -1019,6 +1019,7 @@ class DB2VS(VectorStore):
             distance_strategy=distance_strategy,
             query=query,
             params=params,
+            tablespace=kwargs.get("tablespace"),
         )
         vss.add_texts(texts=list(texts), metadatas=metadatas)
         return vss

--- a/libs/langchain-db2/langchain_db2/db2vs.py
+++ b/libs/langchain-db2/langchain_db2/db2vs.py
@@ -110,6 +110,7 @@ def _create_table(
     client: Connection,
     table_name: str,
     embedding_dim: int,
+    tablespace: str | None = None,
     text_field: str = "text",
     id_field: str = "id",
     metadata_field: str = "metadata",
@@ -127,7 +128,11 @@ def _create_table(
         ddl_body = ", ".join(
             f"{col_name} {col_type}" for col_name, col_type in cols_dict.items()
         )
+        # VECTOR columns require a large-enough page-size tablespace.
+        # Append IN <tablespace> only when the caller supplies one explicitly.
         ddl = f"CREATE TABLE {table_name} ({ddl_body})"
+        if tablespace:
+            ddl += f" IN {tablespace}"
         try:
             cursor.execute(ddl)
             cursor.execute("COMMIT")
@@ -335,8 +340,18 @@ class DB2VS(VectorStore):
         id_field: str = "id",
         metadata_field: str = "metadata",
         embedding_field: str = "embedding",
+        tablespace: str | None = None,
     ):
-        """`DB2VS` vector store."""
+        """`DB2VS` vector store.
+
+        Args:
+            tablespace: Name of an existing 32 K page-size Db2 tablespace to
+                use when creating the vector table.  When ``None`` (default),
+                the library auto-discovers a tablespace the current user is
+                authorised to USE; if none is found it attempts to create
+                ``TS32K``.  Specify this explicitly when your DBA has assigned
+                a particular tablespace (e.g. ``tablespace="TS_SM4K_TC16"``).
+        """
         if client is None:
             if connection_args is not None:
                 database = connection_args.get("database")
@@ -385,10 +400,12 @@ class DB2VS(VectorStore):
             self._id_field = id_field
             self._metadata_field = metadata_field
             self._embedding_field = embedding_field
+            self._tablespace = tablespace
             _create_table(
                 self.client,
                 self.table_name,
                 embedding_dim,
+                tablespace=self._tablespace,
                 text_field=self._text_field,
                 id_field=self._id_field,
                 metadata_field=self._metadata_field,
@@ -1035,73 +1052,79 @@ class DB2VS(VectorStore):
     def create_index(
         self,
         index_name: str,
-        index_type: str = "HNSW",
         accuracy: int | None = None,
         parallel: int | None = None,
         neighbors: int | None = None,
         ef_construction: int | None = None,
     ) -> None:
-        """Create a vector index on the embedding column for ANN search.
+        """Create a DiskANN vector index on the embedding column for ANN search.
 
-        Only ``HNSW`` (Hierarchical Navigable Small World) indexes are
-        supported by Db2 AI Vector Search at this time.  The index uses the
-        distance function that was chosen when this ``DB2VS`` instance was
-        created (``distance_strategy``).
+        Db2 12.1 AI Vector Search uses the ``CREATE VECTOR INDEX`` DDL backed
+        by the DiskANN algorithm.  Only ``EUCLIDEAN`` and
+        ``EUCLIDEAN_SQUARED`` distance metrics are supported for indexing;
+        ``COSINE`` and ``DOT_PRODUCT`` work for ``VECTOR_DISTANCE`` queries
+        but cannot be used to build an index.
 
         Args:
-            index_name: Name for the new index (e.g. ``"HNSW_IDX1"``).
-            index_type: Index algorithm.  Currently only ``"HNSW"`` is
-                supported.  Defaults to ``"HNSW"``.
+            index_name: Name for the new index (e.g. ``"VIDX1"``).
             accuracy: Target accuracy specification (integer 1-100).
                 Mutually exclusive with ``neighbors`` / ``ef_construction``.
                 If omitted, Db2 uses its default accuracy.
             parallel: Number of parallel workers to use during index build.
-                If omitted, Db2 uses its default (8).
-            neighbors: HNSW power-user parameter ``NEIGHBORS``.  Controls the
-                maximum number of bi-directional links per node.  Must be
+                If omitted, Db2 uses its default.
+            neighbors: DiskANN power-user parameter ``NEIGHBORS``.  Controls
+                the maximum number of bi-directional links per node.  Must be
                 provided together with ``ef_construction`` when used.
-            ef_construction: HNSW power-user parameter ``EFCONSTRUCTION``.
+            ef_construction: DiskANN power-user parameter ``EFCONSTRUCTION``.
                 Controls the size of the dynamic candidate list during index
                 construction.  Must be provided together with ``neighbors``
                 when used.
 
         Raises:
-            ValueError: If ``index_type`` is not ``"HNSW"``, or if
+            ValueError: If ``distance_strategy`` is not ``EUCLIDEAN_DISTANCE``
+                or ``MAX_INNER_PRODUCT`` (i.e. not indexable), or if
                 ``accuracy`` is combined with
                 ``neighbors``/``ef_construction``, or if only one of
                 ``neighbors``/``ef_construction`` is given.
             RuntimeError: If a DB2 error occurs while creating the index.
 
-        ??? example "Example - default HNSW index"
+        ??? example "Example - default DiskANN index"
 
             ```python
-            db2vs.create_index("HNSW_IDX1")
+            db2vs.create_index("VIDX1")
             ```
 
         ??? example "Example - with target accuracy and parallel workers"
 
             ```python
             db2vs.create_index(
-                "HNSW_IDX2",
+                "VIDX2",
                 accuracy=97,
                 parallel=16,
             )
             ```
 
-        ??? example "Example - with HNSW power-user parameters"
+        ??? example "Example - with DiskANN power-user parameters"
 
             ```python
             db2vs.create_index(
-                "HNSW_IDX3",
+                "VIDX3",
                 neighbors=64,
                 ef_construction=100,
             )
             ```
 
         """
-        if index_type.upper() != "HNSW":
+        # DiskANN only supports EUCLIDEAN / EUCLIDEAN_SQUARED
+        _INDEXABLE = {
+            DistanceStrategy.EUCLIDEAN_DISTANCE,
+            DistanceStrategy.MAX_INNER_PRODUCT,
+        }
+        if self.distance_strategy not in _INDEXABLE:
             error_msg = (
-                f"Unsupported index type '{index_type}'. Only 'HNSW' is supported."
+                f"distance_strategy '{self.distance_strategy}' cannot be used to "
+                "build a DiskANN vector index. Only EUCLIDEAN_DISTANCE and "
+                "MAX_INNER_PRODUCT (EUCLIDEAN_SQUARED) are supported."
             )
             raise ValueError(error_msg)
 
@@ -1123,9 +1146,8 @@ class DB2VS(VectorStore):
 
         distance_func = _get_distance_function(self.distance_strategy)
         ddl = (
-            f"CREATE INDEX {index_name} ON {self.table_name} ({self._embedding_field}) "
-            f"USING {index_type.upper()} "
-            f"DISTANCE {distance_func}"
+            f"CREATE VECTOR INDEX {index_name} ON {self.table_name} "
+            f"({self._embedding_field}) WITH DISTANCE {distance_func}"
         )
 
         if has_accuracy:

--- a/libs/langchain-db2/langchain_db2/db2vs.py
+++ b/libs/langchain-db2/langchain_db2/db2vs.py
@@ -345,12 +345,15 @@ class DB2VS(VectorStore):
         """`DB2VS` vector store.
 
         Args:
-            tablespace: Name of an existing 32 K page-size Db2 tablespace to
-                use when creating the vector table.  When ``None`` (default),
-                the library auto-discovers a tablespace the current user is
-                authorised to USE; if none is found it attempts to create
-                ``TS32K``.  Specify this explicitly when your DBA has assigned
-                a particular tablespace (e.g. ``tablespace="TS_SM4K_TC16"``).
+            tablespace: Name of a Db2 tablespace to use when creating the
+                vector table.  The tablespace must have a page size large
+                enough to hold a full row containing the VECTOR column
+                (e.g. a 768-dim FLOAT32 vector occupies 3072 bytes, so any
+                page size ≥ 8K works).  When ``None`` (default) no ``IN``
+                clause is added and Db2 uses the user's default tablespace.
+                Specify this when the default tablespace has a 4K page size
+                and would reject the VECTOR column
+                (e.g. ``tablespace="TS32K"``).
         """
         if client is None:
             if connection_args is not None:
@@ -379,10 +382,8 @@ class DB2VS(VectorStore):
                 error_msg = "No valid connection or connection_args is passed"
                 raise ValueError(error_msg)
         else:
-            """Initialize with ibm_db_dbi client."""
             self.client = client
         try:
-            """Initialize with necessary components."""
             if not isinstance(embedding_function, EmbeddingsSchema):
                 logger.warning(
                     "`embedding_function` is expected to be an Embeddings "

--- a/libs/langchain-db2/langchain_db2/db2vs.py
+++ b/libs/langchain-db2/langchain_db2/db2vs.py
@@ -111,12 +111,15 @@ def _create_table(
     table_name: str,
     embedding_dim: int,
     text_field: str = "text",
+    id_field: str = "id",
+    metadata_field: str = "metadata",
+    embedding_field: str = "embedding",
 ) -> None:
     cols_dict = {
-        "id": "CHAR(16) PRIMARY KEY NOT NULL",
+        id_field: "CHAR(16) PRIMARY KEY NOT NULL",
         text_field: "CLOB",
-        "metadata": "BLOB",
-        "embedding": f"vector({embedding_dim}, FLOAT32)",
+        metadata_field: "BLOB",
+        embedding_field: f"vector({embedding_dim}, FLOAT32)",
     }
 
     if not _table_exists(client, table_name):
@@ -173,6 +176,45 @@ def drop_table(client: Connection, table_name: str) -> None:
     else:
         info_msg = f"Table {table_name} not found..."
         logger.info(info_msg)
+
+
+@_handle_exceptions
+def drop_index(client: Connection, index_name: str) -> None:
+    """Drop a vector index from the database if it exists.
+
+    Args:
+        client: The `ibm_db_dbi` connection object
+        index_name: The name of the index to drop
+
+    Raises:
+        RuntimeError: If an error occurs while dropping the index
+
+    ??? example "Example"
+
+        ```python
+        from langchain_db2.db2vs import drop_index
+
+        drop_index(
+            client=db_client,  # ibm_db_dbi.Connection
+            index_name="HNSW_IDX1",
+        )
+        ```
+
+    """
+    cursor = client.cursor()
+    try:
+        cursor.execute(f"DROP INDEX {index_name}")
+        cursor.execute("COMMIT")
+        info_msg = f"Index {index_name} dropped successfully..."
+        logger.info(info_msg)
+    except Exception as ex:
+        if "SQL0204N" in str(ex):
+            info_msg = f"Index {index_name} not found..."
+            logger.info(info_msg)
+        else:
+            raise
+    finally:
+        cursor.close()
 
 
 @_handle_exceptions
@@ -290,6 +332,9 @@ class DB2VS(VectorStore):
         params: dict[str, Any] | None = None,
         connection_args: dict[str, Any] | None = None,
         text_field: str = "text",
+        id_field: str = "id",
+        metadata_field: str = "metadata",
+        embedding_field: str = "embedding",
     ):
         """`DB2VS` vector store."""
         if client is None:
@@ -308,6 +353,11 @@ class DB2VS(VectorStore):
                 if "security" in connection_args:
                     security = connection_args.get("security")
                     conn_str += f"security={security};"
+                    # ssl_cert: path to the server certificate file (.arm/.pem).
+                    # Only appended when security is also enabled.
+                    ssl_cert = connection_args.get("ssl_cert", "")
+                    if ssl_cert:
+                        conn_str += f"SSLServerCertificate={ssl_cert};"
 
                 self.client = ibm_db_dbi.connect(conn_str, "", "")
             else:
@@ -332,11 +382,17 @@ class DB2VS(VectorStore):
             self.distance_strategy = distance_strategy
             self.params = params
             self._text_field = text_field
+            self._id_field = id_field
+            self._metadata_field = metadata_field
+            self._embedding_field = embedding_field
             _create_table(
                 self.client,
                 self.table_name,
                 embedding_dim,
                 text_field=self._text_field,
+                id_field=self._id_field,
+                metadata_field=self._metadata_field,
+                embedding_field=self._embedding_field,
             )
         except ibm_db_dbi.DatabaseError as db_err:
             exception_msg = f"Database error occurred while create table: {db_err}"
@@ -470,7 +526,9 @@ class DB2VS(VectorStore):
         if not metadatas:
             metadatas = [{} for _ in texts]
 
-        embedding_len = self.get_embedding_dimension()
+        # Derive dimension directly from the already-computed embeddings — no
+        # second round-trip to the embedding model.
+        embedding_len = len(embeddings[0]) if embeddings else self.get_embedding_dimension()
         docs: list[tuple[Any, Any, Any, Any]]
         docs = [
             (id_, f"{embedding}", json.dumps(metadata), text)
@@ -485,7 +543,8 @@ class DB2VS(VectorStore):
 
         sql_insert = (
             f"INSERT INTO "  # noqa: S608
-            f"{self.table_name} (id, embedding, metadata, {self._text_field}) "
+            f"{self.table_name} ({self._id_field}, {self._embedding_field}, "
+            f"{self._metadata_field}, {self._text_field}) "
             f"VALUES (?, VECTOR(cast(? as CLOB(100000)), {embedding_len}, FLOAT32), "
             f"SYSTOOLS.JSON2BSON(?), ?)"
         )
@@ -516,8 +575,7 @@ class DB2VS(VectorStore):
         Returns:
             Documents most similar to a query
         """
-        if isinstance(self.embedding_function, EmbeddingsSchema):
-            embedding = self.embedding_function.embed_query(query)
+        embedding = self._embed_query(query)
         return self.similarity_search_by_vector(
             embedding=embedding,
             k=k,
@@ -571,8 +629,7 @@ class DB2VS(VectorStore):
                 The score is the vector **distance**; lower values indicate
                 closer matches.
         """
-        if isinstance(self.embedding_function, EmbeddingsSchema):
-            embedding = self.embedding_function.embed_query(query)
+        embedding = self._embed_query(query)
         return self.similarity_search_by_vector_with_relevance_scores(
             embedding=embedding,
             k=k,
@@ -601,11 +658,11 @@ class DB2VS(VectorStore):
         docs_and_scores = []
         embedding_len = self.get_embedding_dimension()
 
-        query = f"""
-        SELECT id,
+        sql = f"""
+        SELECT {self._id_field},
           {self._text_field},
-          SYSTOOLS.BSON2JSON(metadata),
-          vector_distance(embedding, VECTOR('{embedding}', {embedding_len}, FLOAT32),
+          SYSTOOLS.BSON2JSON({self._metadata_field}),
+          vector_distance({self._embedding_field}, VECTOR('{embedding}', {embedding_len}, FLOAT32),
           {_get_distance_function(self.distance_strategy)}) as distance
         FROM {self.table_name}
         ORDER BY distance
@@ -617,16 +674,21 @@ class DB2VS(VectorStore):
         # Execute the query
         cursor = self.client.cursor()
         try:
-            cursor.execute(query)
+            cursor.execute(sql)
             results = cursor.fetchall()
 
-            # Filter results if filter is provided
+            # Filter results if filter is provided.
+            # filter values must be lists, e.g. {"source": ["wiki", "news"]}.
             for result in results:
                 metadata = json.loads(result[2] if result[2] is not None else "{}")
 
                 # Apply filtering based on the 'filter' dictionary
                 if filter:
-                    if all(metadata.get(key) in value for key, value in filter.items()):
+                    if all(
+                        metadata.get(key) in value
+                        for key, value in filter.items()
+                        if isinstance(value, list)
+                    ):
                         doc = Document(
                             page_content=(result[1] if result[1] is not None else ""),
                             metadata=metadata,
@@ -665,13 +727,13 @@ class DB2VS(VectorStore):
         documents = []
         embedding_len = self.get_embedding_dimension()
 
-        query = f"""
-        SELECT id,
+        sql = f"""
+        SELECT {self._id_field},
           {self._text_field},
-          SYSTOOLS.BSON2JSON(metadata),
-          vector_distance(embedding, VECTOR('{embedding}', {embedding_len}, FLOAT32),
+          SYSTOOLS.BSON2JSON({self._metadata_field}),
+          vector_distance({self._embedding_field}, VECTOR('{embedding}', {embedding_len}, FLOAT32),
           {_get_distance_function(self.distance_strategy)}) as distance,
-          embedding
+          {self._embedding_field}
         FROM {self.table_name}
         ORDER BY distance
         FETCH FIRST {k} ROWS ONLY
@@ -682,32 +744,35 @@ class DB2VS(VectorStore):
         # Execute the query
         cursor = self.client.cursor()
         try:
-            cursor.execute(query)
+            cursor.execute(sql)
             results = cursor.fetchall()
 
             for result in results:
+                # Skip rows whose embedding column is NULL — passing a zero-
+                # length array into maximal_marginal_relevance causes a NumPy
+                # shape mismatch crash.
+                if result[4] is None:
+                    continue
+
                 page_content_str = result[1] if result[1] is not None else ""
                 metadata = json.loads(result[2] if result[2] is not None else "{}")
 
                 # Apply filter if provided and matches; otherwise, add all
-                # documents
+                # documents.
+                # filter values must be lists, e.g. {"source": ["wiki"]}.
                 if not filter or all(
-                    metadata.get(key) in value for key, value in filter.items()
+                    metadata.get(key) in value
+                    for key, value in filter.items()
+                    if isinstance(value, list)
                 ):
                     document = Document(
                         page_content=page_content_str,
                         metadata=metadata,
                     )
                     distance = result[3]
-
-                    # Assuming result[4] is already in the correct format;
-                    # adjust if necessary
-                    current_embedding = (
-                        np.array(json.loads(result[4]), dtype=np.float32)
-                        if result[4]
-                        else np.empty(0, dtype=np.float32)
+                    current_embedding = np.array(
+                        json.loads(result[4]), dtype=np.float32
                     )
-
                     documents.append((document, distance, current_embedding))
         finally:
             cursor.close()
@@ -878,7 +943,7 @@ class DB2VS(VectorStore):
         # Constructing the SQL statement with individual placeholders
         placeholders = ", ".join("?" for _ in hashed_ids)
 
-        ddl = f"DELETE FROM {self.table_name} WHERE id IN ({placeholders})"  # noqa: S608
+        ddl = f"DELETE FROM {self.table_name} WHERE {self._id_field} IN ({placeholders})"  # noqa: S608
         cursor = self.client.cursor()
         try:
             cursor.execute(ddl, hashed_ids)
@@ -914,10 +979,14 @@ class DB2VS(VectorStore):
 
         table_name = str(kwargs.get("table_name", "langchain"))
 
-        distance_strategy = cast("DistanceStrategy", kwargs.get("distance_strategy"))
+        # Default to EUCLIDEAN_DISTANCE when not supplied, matching __init__.
+        # Previously this raised TypeError for any caller that omitted the arg.
+        distance_strategy = kwargs.get(
+            "distance_strategy", DistanceStrategy.EUCLIDEAN_DISTANCE
+        )
         if not isinstance(distance_strategy, DistanceStrategy):
-            error_msg = (  # type: ignore[unreachable]
-                f"Expected DistanceStrategy got {type(distance_strategy).__name__} "
+            error_msg = (
+                f"Expected DistanceStrategy, got {type(distance_strategy).__name__}"
             )
             raise TypeError(error_msg)
 
@@ -948,7 +1017,7 @@ class DB2VS(VectorStore):
         Returns:
             List of matching primary-key values.
         """
-        sql = f"SELECT id FROM {self.table_name}"  # noqa: S608
+        sql = f"SELECT {self._id_field} FROM {self.table_name}"  # noqa: S608
 
         if expr:
             sql += f" WHERE {expr}"
@@ -961,3 +1030,121 @@ class DB2VS(VectorStore):
             cursor.close()
 
         return [row[0] for row in rows]
+
+    @_handle_exceptions
+    def create_index(
+        self,
+        index_name: str,
+        index_type: str = "HNSW",
+        accuracy: int | None = None,
+        parallel: int | None = None,
+        neighbors: int | None = None,
+        ef_construction: int | None = None,
+    ) -> None:
+        """Create a vector index on the embedding column for ANN search.
+
+        Only ``HNSW`` (Hierarchical Navigable Small World) indexes are
+        supported by Db2 AI Vector Search at this time.  The index uses the
+        distance function that was chosen when this ``DB2VS`` instance was
+        created (``distance_strategy``).
+
+        Args:
+            index_name: Name for the new index (e.g. ``"HNSW_IDX1"``).
+            index_type: Index algorithm.  Currently only ``"HNSW"`` is
+                supported.  Defaults to ``"HNSW"``.
+            accuracy: Target accuracy specification (integer 1-100).
+                Mutually exclusive with ``neighbors`` / ``ef_construction``.
+                If omitted, Db2 uses its default accuracy.
+            parallel: Number of parallel workers to use during index build.
+                If omitted, Db2 uses its default (8).
+            neighbors: HNSW power-user parameter ``NEIGHBORS``.  Controls the
+                maximum number of bi-directional links per node.  Must be
+                provided together with ``ef_construction`` when used.
+            ef_construction: HNSW power-user parameter ``EFCONSTRUCTION``.
+                Controls the size of the dynamic candidate list during index
+                construction.  Must be provided together with ``neighbors``
+                when used.
+
+        Raises:
+            ValueError: If ``index_type`` is not ``"HNSW"``, or if
+                ``accuracy`` is combined with
+                ``neighbors``/``ef_construction``, or if only one of
+                ``neighbors``/``ef_construction`` is given.
+            RuntimeError: If a DB2 error occurs while creating the index.
+
+        ??? example "Example - default HNSW index"
+
+            ```python
+            db2vs.create_index("HNSW_IDX1")
+            ```
+
+        ??? example "Example - with target accuracy and parallel workers"
+
+            ```python
+            db2vs.create_index(
+                "HNSW_IDX2",
+                accuracy=97,
+                parallel=16,
+            )
+            ```
+
+        ??? example "Example - with HNSW power-user parameters"
+
+            ```python
+            db2vs.create_index(
+                "HNSW_IDX3",
+                neighbors=64,
+                ef_construction=100,
+            )
+            ```
+
+        """
+        if index_type.upper() != "HNSW":
+            error_msg = (
+                f"Unsupported index type '{index_type}'. Only 'HNSW' is supported."
+            )
+            raise ValueError(error_msg)
+
+        has_accuracy = accuracy is not None
+        has_power = neighbors is not None or ef_construction is not None
+
+        if has_accuracy and has_power:
+            error_msg = (
+                "'accuracy' cannot be combined with 'neighbors' / 'ef_construction'. "
+                "Use either target accuracy or power-user parameters, not both."
+            )
+            raise ValueError(error_msg)
+
+        if (neighbors is None) != (ef_construction is None):
+            error_msg = (
+                "'neighbors' and 'ef_construction' must be specified together."
+            )
+            raise ValueError(error_msg)
+
+        distance_func = _get_distance_function(self.distance_strategy)
+        ddl = (
+            f"CREATE INDEX {index_name} ON {self.table_name} ({self._embedding_field}) "
+            f"USING {index_type.upper()} "
+            f"DISTANCE {distance_func}"
+        )
+
+        if has_accuracy:
+            ddl += f" WITH TARGET ACCURACY {accuracy}"
+
+        if parallel is not None:
+            ddl += f" PARALLEL {parallel}"
+
+        if has_power:
+            ddl += (
+                f" PARAMETERS (NEIGHBORS {neighbors}"
+                f" EFCONSTRUCTION {ef_construction})"
+            )
+
+        cursor = self.client.cursor()
+        try:
+            cursor.execute(ddl)
+            cursor.execute("COMMIT")
+            info_msg = f"Index {index_name} created successfully on {self.table_name}."
+            logger.info(info_msg)
+        finally:
+            cursor.close()

--- a/libs/langchain-db2/langchain_db2/db2vs.py
+++ b/libs/langchain-db2/langchain_db2/db2vs.py
@@ -1155,7 +1155,8 @@ class DB2VS(VectorStore):
             ddl += f" WITH TARGET ACCURACY {accuracy}"
 
         if parallel is not None:
-            ddl += f" PARALLEL {parallel}"
+            # The Db2 DDL keyword is BUILD_PARALLELISM, not PARALLEL.
+            ddl += f" BUILD_PARALLELISM {parallel}"
 
         if has_power:
             ddl += (

--- a/libs/langchain-db2/langchain_db2/db2vs.py
+++ b/libs/langchain-db2/langchain_db2/db2vs.py
@@ -105,6 +105,28 @@ def _get_distance_function(distance_strategy: DistanceStrategy) -> str:
     raise ValueError(error_msg)
 
 
+def _quote_ident(name: str) -> str:
+    """Return a safely double-quoted, upper-cased Db2 identifier.
+
+    Converts the identifier to uppercase and wraps it in double quotes,
+    escaping any embedded double-quote characters by doubling them.  This
+    matches Db2's default identifier semantics for DDL statements.
+
+    Args:
+        name: A non-empty identifier string (table, index, column, schema).
+
+    Returns:
+        A double-quoted, uppercase string safe for Db2 DDL/DML.
+
+    Raises:
+        ValueError: If ``name`` is empty or whitespace-only.
+    """
+    if not name or not name.strip():
+        error_msg = "Identifier must be a non-empty string."
+        raise ValueError(error_msg)
+    return '"' + name.upper().replace('"', '""') + '"'
+
+
 @_handle_exceptions
 def _create_table(
     client: Connection,
@@ -1054,6 +1076,7 @@ class DB2VS(VectorStore):
     def create_index(
         self,
         index_name: str,
+        if_exists: str = "error",
         accuracy: int | None = None,
         parallel: int | None = None,
         neighbors: int | None = None,
@@ -1062,38 +1085,52 @@ class DB2VS(VectorStore):
         """Create a DiskANN vector index on the embedding column for ANN search.
 
         Db2 12.1 AI Vector Search uses the ``CREATE VECTOR INDEX`` DDL backed
-        by the DiskANN algorithm.  The supported distance metrics for indexing
-        are ``EUCLIDEAN``, ``EUCLIDEAN_SQUARED``, and ``COSINE``.
-        ``DOT_PRODUCT`` (``DOT``) is **not** a valid keyword for
-        ``CREATE VECTOR INDEX`` and will be rejected by the engine
-        (``SQL0104N``).
+        by the DiskANN algorithm.  Supported distance metrics are
+        ``EUCLIDEAN``, ``EUCLIDEAN_SQUARED``, and ``COSINE``.
+        ``DOT_PRODUCT`` is **not** a valid index distance keyword in Db2 12.1
+        and is rejected by the engine with ``SQL0104N``.
+
+        After building the index, ``RUNSTATS`` is run automatically so the
+        Db2 optimizer can immediately take advantage of the new index.
 
         Args:
             index_name: Name for the new index (e.g. ``"VIDX1"``).
-            accuracy: Target accuracy specification (integer 1-100).
+            if_exists: Behaviour when an index with ``index_name`` already
+                exists.  One of:
+
+                * ``"error"`` *(default)* — raise ``ValueError``.
+                * ``"skip"`` — return silently without rebuilding.
+                * ``"replace"`` — drop the existing index and recreate it.
+
+            accuracy: Target accuracy specification (integer 1–100).
                 Mutually exclusive with ``neighbors`` / ``ef_construction``.
                 If omitted, Db2 uses its default accuracy.
-            parallel: Number of parallel workers to use during index build.
-                If omitted, Db2 uses its default.
-            neighbors: DiskANN power-user parameter ``NEIGHBORS``.  Controls
-                the maximum number of bi-directional links per node.  Must be
-                provided together with ``ef_construction`` when used.
-            ef_construction: DiskANN power-user parameter ``EFCONSTRUCTION``.
-                Controls the size of the dynamic candidate list during index
-                construction.  Must be provided together with ``neighbors``
-                when used.
+            parallel: Number of parallel workers for index build
+                (``BUILD_PARALLELISM``).  If omitted, Db2 uses its default.
+            neighbors: DiskANN ``MAX_NODE_DEGREE``.  Controls the maximum
+                number of bi-directional links per graph node.  Must be
+                provided together with ``ef_construction``.
+            ef_construction: DiskANN ``BUILD_LIST_SIZE``.  Controls the
+                dynamic candidate-list size during construction.  Must be
+                provided together with ``neighbors``.
 
         Raises:
-            ValueError: If ``distance_strategy`` is ``DOT_PRODUCT`` (not a
-                valid index distance in Db2 12.1), or if ``accuracy`` is
-                combined with ``neighbors``/``ef_construction``, or if only
-                one of ``neighbors``/``ef_construction`` is given.
-            RuntimeError: If a DB2 error occurs while creating the index.
+            ValueError: If ``distance_strategy`` is ``DOT_PRODUCT``, if
+                ``if_exists`` is not one of the three accepted values, if
+                ``accuracy`` is combined with ``neighbors``/``ef_construction``,
+                or if only one of ``neighbors``/``ef_construction`` is given.
+            RuntimeError: If a Db2 error occurs while creating the index.
 
         ??? example "Example - default DiskANN index"
 
             ```python
             db2vs.create_index("VIDX1")
+            ```
+
+        ??? example "Example - idempotent rebuild"
+
+            ```python
+            db2vs.create_index("VIDX1", if_exists="replace")
             ```
 
         ??? example "Example - with target accuracy and parallel workers"
@@ -1117,9 +1154,15 @@ class DB2VS(VectorStore):
             ```
 
         """
-        # DOT_PRODUCT ("DOT") is not a valid distance keyword for
-        # CREATE VECTOR INDEX — the engine returns SQL0104N syntax error.
-        # EUCLIDEAN, EUCLIDEAN_SQUARED, and COSINE are all supported.
+        # ── Validate if_exists ──────────────────────────────────────────────
+        if if_exists not in ("error", "skip", "replace"):
+            error_msg = (
+                f"if_exists must be one of 'error', 'skip', 'replace'; "
+                f"got '{if_exists}'."
+            )
+            raise ValueError(error_msg)
+
+        # ── DOT_PRODUCT is not a valid index distance keyword (SQL0104N) ────
         if self.distance_strategy == DistanceStrategy.DOT_PRODUCT:
             error_msg = (
                 "distance_strategy 'DOT_PRODUCT' cannot be used to build a "
@@ -1129,6 +1172,7 @@ class DB2VS(VectorStore):
             )
             raise ValueError(error_msg)
 
+        # ── Mutual-exclusion guards ──────────────────────────────────────────
         has_accuracy = accuracy is not None
         has_power = neighbors is not None or ef_construction is not None
 
@@ -1145,17 +1189,48 @@ class DB2VS(VectorStore):
             )
             raise ValueError(error_msg)
 
+        # ── if_exists: check catalog, then skip/drop as needed ──────────────
+        cursor = self.client.cursor()
+        try:
+            cursor.execute(
+                "SELECT 1 FROM SYSCAT.INDEXES "
+                "WHERE UPPER(INDNAME) = UPPER(?) "
+                "FETCH FIRST 1 ROW ONLY",
+                (index_name,),
+            )
+            already_exists = cursor.fetchone() is not None
+        finally:
+            cursor.close()
+
+        if already_exists:
+            if if_exists == "skip":
+                logger.info("Index %s already exists — skipping.", index_name)
+                return
+            if if_exists == "replace":
+                logger.info("Index %s already exists — dropping for replace.", index_name)
+                drop_index(self.client, index_name)
+            else:  # "error"
+                error_msg = (
+                    f"Index '{index_name}' already exists. "
+                    "Pass if_exists='skip' to ignore or if_exists='replace' to rebuild."
+                )
+                raise ValueError(error_msg)
+
+        # ── Build DDL using safely quoted identifiers ────────────────────────
         distance_func = _get_distance_function(self.distance_strategy)
+        q_index = _quote_ident(index_name)
+        q_table = self.table_name   # may be schema-qualified; preserve as-is
+        q_col   = _quote_ident(self._embedding_field)
+
         ddl = (
-            f"CREATE VECTOR INDEX {index_name} ON {self.table_name} "
-            f"({self._embedding_field}) WITH DISTANCE {distance_func}"
+            f"CREATE VECTOR INDEX {q_index} ON {q_table} "
+            f"({q_col}) WITH DISTANCE {distance_func}"
         )
 
         if has_accuracy:
             ddl += f" WITH TARGET ACCURACY {accuracy}"
 
         if parallel is not None:
-            # The Db2 DDL keyword is BUILD_PARALLELISM, not PARALLEL.
             ddl += f" BUILD_PARALLELISM {parallel}"
 
         if has_power:
@@ -1164,11 +1239,31 @@ class DB2VS(VectorStore):
                 f" EFCONSTRUCTION {ef_construction})"
             )
 
+        # ── Execute DDL ──────────────────────────────────────────────────────
         cursor = self.client.cursor()
         try:
             cursor.execute(ddl)
             cursor.execute("COMMIT")
-            info_msg = f"Index {index_name} created successfully on {self.table_name}."
-            logger.info(info_msg)
+        finally:
+            cursor.close()
+
+        logger.info("Index %s created on %s.", index_name, self.table_name)
+
+        # ── RUNSTATS so the optimizer can immediately use the new index ───────
+        runstats = (
+            f"CALL SYSPROC.ADMIN_CMD("
+            f"'RUNSTATS ON TABLE {q_table} FOR INDEXES ALL')"
+        )
+        cursor = self.client.cursor()
+        try:
+            cursor.execute(runstats)
+            cursor.execute("COMMIT")
+        except Exception:
+            # RUNSTATS failure is non-fatal — the index was already created.
+            logger.warning(
+                "RUNSTATS failed for table %s. "
+                "Statistics may be stale; consider running RUNSTATS manually.",
+                q_table,
+            )
         finally:
             cursor.close()

--- a/libs/langchain-db2/langchain_db2/db2vs.py
+++ b/libs/langchain-db2/langchain_db2/db2vs.py
@@ -1062,10 +1062,11 @@ class DB2VS(VectorStore):
         """Create a DiskANN vector index on the embedding column for ANN search.
 
         Db2 12.1 AI Vector Search uses the ``CREATE VECTOR INDEX`` DDL backed
-        by the DiskANN algorithm.  Only ``EUCLIDEAN`` and
-        ``EUCLIDEAN_SQUARED`` distance metrics are supported for indexing;
-        ``COSINE`` and ``DOT_PRODUCT`` work for ``VECTOR_DISTANCE`` queries
-        but cannot be used to build an index.
+        by the DiskANN algorithm.  The supported distance metrics for indexing
+        are ``EUCLIDEAN``, ``EUCLIDEAN_SQUARED``, and ``COSINE``.
+        ``DOT_PRODUCT`` (``DOT``) is **not** a valid keyword for
+        ``CREATE VECTOR INDEX`` and will be rejected by the engine
+        (``SQL0104N``).
 
         Args:
             index_name: Name for the new index (e.g. ``"VIDX1"``).
@@ -1083,11 +1084,10 @@ class DB2VS(VectorStore):
                 when used.
 
         Raises:
-            ValueError: If ``distance_strategy`` is not ``EUCLIDEAN_DISTANCE``
-                or ``MAX_INNER_PRODUCT`` (i.e. not indexable), or if
-                ``accuracy`` is combined with
-                ``neighbors``/``ef_construction``, or if only one of
-                ``neighbors``/``ef_construction`` is given.
+            ValueError: If ``distance_strategy`` is ``DOT_PRODUCT`` (not a
+                valid index distance in Db2 12.1), or if ``accuracy`` is
+                combined with ``neighbors``/``ef_construction``, or if only
+                one of ``neighbors``/``ef_construction`` is given.
             RuntimeError: If a DB2 error occurs while creating the index.
 
         ??? example "Example - default DiskANN index"
@@ -1117,16 +1117,15 @@ class DB2VS(VectorStore):
             ```
 
         """
-        # DiskANN only supports EUCLIDEAN / EUCLIDEAN_SQUARED
-        _INDEXABLE = {
-            DistanceStrategy.EUCLIDEAN_DISTANCE,
-            DistanceStrategy.MAX_INNER_PRODUCT,
-        }
-        if self.distance_strategy not in _INDEXABLE:
+        # DOT_PRODUCT ("DOT") is not a valid distance keyword for
+        # CREATE VECTOR INDEX — the engine returns SQL0104N syntax error.
+        # EUCLIDEAN, EUCLIDEAN_SQUARED, and COSINE are all supported.
+        if self.distance_strategy == DistanceStrategy.DOT_PRODUCT:
             error_msg = (
-                f"distance_strategy '{self.distance_strategy}' cannot be used to "
-                "build a DiskANN vector index. Only EUCLIDEAN_DISTANCE and "
-                "MAX_INNER_PRODUCT (EUCLIDEAN_SQUARED) are supported."
+                "distance_strategy 'DOT_PRODUCT' cannot be used to build a "
+                "DiskANN vector index. Db2 12.1 does not support DOT as an "
+                "index distance keyword (SQL0104N). Use EUCLIDEAN_DISTANCE, "
+                "MAX_INNER_PRODUCT (EUCLIDEAN_SQUARED), or COSINE instead."
             )
             raise ValueError(error_msg)
 

--- a/libs/langchain-db2/langchain_db2/db2vs.py
+++ b/libs/langchain-db2/langchain_db2/db2vs.py
@@ -577,7 +577,6 @@ class DB2VS(VectorStore):
                 embeddings,
                 metadatas,
                 texts,
-                strict=False,
             )
         ]
 
@@ -860,7 +859,7 @@ class DB2VS(VectorStore):
         # If you need to split documents and scores for processing (e.g.,
         # for MMR calculation)
         documents, scores, embeddings = (
-            zip(*docs_scores_embeddings, strict=False)
+            zip(*docs_scores_embeddings)
             if docs_scores_embeddings
             else ([], [], [])
         )

--- a/libs/langchain-db2/langchain_db2/db2vs.py
+++ b/libs/langchain-db2/langchain_db2/db2vs.py
@@ -1076,7 +1076,6 @@ class DB2VS(VectorStore):
         self,
         index_name: str,
         if_exists: str = "error",
-        accuracy: int | None = None,
         parallel: int | None = None,
         neighbors: int | None = None,
         ef_construction: int | None = None,
@@ -1101,23 +1100,19 @@ class DB2VS(VectorStore):
                 * ``"skip"`` — return silently without rebuilding.
                 * ``"replace"`` — drop the existing index and recreate it.
 
-            accuracy: Target accuracy specification (integer 1–100).
-                Mutually exclusive with ``neighbors`` / ``ef_construction``.
-                If omitted, Db2 uses its default accuracy.
             parallel: Number of parallel workers for index build
                 (``BUILD_PARALLELISM``).  If omitted, Db2 uses its default.
-            neighbors: DiskANN ``MAX_NODE_DEGREE``.  Controls the maximum
-                number of bi-directional links per graph node.  Must be
-                provided together with ``ef_construction``.
-            ef_construction: DiskANN ``BUILD_LIST_SIZE``.  Controls the
-                dynamic candidate-list size during construction.  Must be
-                provided together with ``neighbors``.
+            neighbors: Maximum number of bi-directional links per graph node
+                (``MAX_NODE_DEGREE``).  If omitted, Db2 uses its default.
+                Must be provided together with ``ef_construction``.
+            ef_construction: Dynamic candidate-list size during construction
+                (``BUILD_LIST_SIZE``).  If omitted, Db2 uses its default.
+                Must be provided together with ``neighbors``.
 
         Raises:
             ValueError: If ``distance_strategy`` is ``DOT_PRODUCT``, if
-                ``if_exists`` is not one of the three accepted values, if
-                ``accuracy`` is combined with ``neighbors``/``ef_construction``,
-                or if only one of ``neighbors``/``ef_construction`` is given.
+                ``if_exists`` is not one of the three accepted values, or if
+                only one of ``neighbors``/``ef_construction`` is given.
             RuntimeError: If a Db2 error occurs while creating the index.
 
         ??? example "Example - default DiskANN index"
@@ -1132,17 +1127,13 @@ class DB2VS(VectorStore):
             db2vs.create_index("VIDX1", if_exists="replace")
             ```
 
-        ??? example "Example - with target accuracy and parallel workers"
+        ??? example "Example - with parallel workers"
 
             ```python
-            db2vs.create_index(
-                "VIDX2",
-                accuracy=97,
-                parallel=16,
-            )
+            db2vs.create_index("VIDX2", parallel=16)
             ```
 
-        ??? example "Example - with DiskANN power-user parameters"
+        ??? example "Example - with DiskANN tuning parameters"
 
             ```python
             db2vs.create_index(
@@ -1171,17 +1162,7 @@ class DB2VS(VectorStore):
             )
             raise ValueError(error_msg)
 
-        # ── Mutual-exclusion guards ──────────────────────────────────────────
-        has_accuracy = accuracy is not None
-        has_power = neighbors is not None or ef_construction is not None
-
-        if has_accuracy and has_power:
-            error_msg = (
-                "'accuracy' cannot be combined with 'neighbors' / 'ef_construction'. "
-                "Use either target accuracy or power-user parameters, not both."
-            )
-            raise ValueError(error_msg)
-
+        # ── neighbors and ef_construction must both be given or both omitted ─
         if (neighbors is None) != (ef_construction is None):
             error_msg = (
                 "'neighbors' and 'ef_construction' must be specified together."
@@ -1226,17 +1207,14 @@ class DB2VS(VectorStore):
             f"({q_col}) WITH DISTANCE {distance_func}"
         )
 
-        if has_accuracy:
-            ddl += f" WITH TARGET ACCURACY {accuracy}"
-
         if parallel is not None:
             ddl += f" BUILD_PARALLELISM {parallel}"
 
-        if has_power:
-            ddl += (
-                f" PARAMETERS (NEIGHBORS {neighbors}"
-                f" EFCONSTRUCTION {ef_construction})"
-            )
+        if neighbors is not None:
+            ddl += f" MAX_NODE_DEGREE {neighbors}"
+
+        if ef_construction is not None:
+            ddl += f" BUILD_LIST_SIZE {ef_construction}"
 
         # ── Execute DDL ──────────────────────────────────────────────────────
         cursor = self.client.cursor()

--- a/libs/langchain-db2/tests/integration_tests/.env.example
+++ b/libs/langchain-db2/tests/integration_tests/.env.example
@@ -3,6 +3,12 @@ DB2_HOST=db2_host
 DB2_PORT=db2_port
 DB2_USER=db2_user
 DB2_PASSWORD=db2_password
+# Set to "true" for SSL/TLS connections (e.g. IBM Cloud). Leave false for
+# plain-TCP on-prem servers.
+DB2_SSL=false
+# Absolute path to the server SSL certificate file (.arm or .pem).
+# Only used when DB2_SSL=true. Leave blank to rely on the system truststore.
+DB2_SSL_CERT=
 
 DB2_CONNECT_USER=
 DB2_CONNECT_PASSWORD=

--- a/libs/langchain-db2/tests/integration_tests/.env.example
+++ b/libs/langchain-db2/tests/integration_tests/.env.example
@@ -1,6 +1,7 @@
 DB2_NAME=db2_name
 DB2_HOST=db2_host
 DB2_PORT=db2_port
+# Primary user — must have DBADM to run CREATE VECTOR INDEX tests.
 DB2_USER=db2_user
 DB2_PASSWORD=db2_password
 # Set to "true" for SSL/TLS connections (e.g. IBM Cloud). Leave false for
@@ -12,3 +13,9 @@ DB2_SSL_CERT=
 
 DB2_CONNECT_USER=
 DB2_CONNECT_PASSWORD=
+
+# Optional: a second user with NO DBADM, used to prove that CREATE VECTOR INDEX
+# requires DBADM and fails with SQL0551N for limited-privilege users.
+# If left blank, the privilege-boundary tests are automatically skipped.
+DB2_LIMITED_USER=
+DB2_LIMITED_PASSWORD=

--- a/libs/langchain-db2/tests/integration_tests/conftest.py
+++ b/libs/langchain-db2/tests/integration_tests/conftest.py
@@ -2,6 +2,7 @@ import contextlib
 import os
 from collections.abc import Generator
 from pathlib import Path
+from typing import Optional
 
 import ibm_db_dbi  # type: ignore[import-untyped]
 import pytest
@@ -15,8 +16,29 @@ ABS_PATH = (Path(__file__)).parent
 PROJECT_DIR = Path(ABS_PATH).parent.parent
 
 
+def _make_connection(
+    user: str,
+    password: str,
+    name: str,
+    host: str,
+    port: str,
+    ssl: bool,
+    ssl_cert: str,
+    connect_user: str = "",
+    connect_password: str = "",
+) -> ibm_db_dbi.Connection:
+    """Build a Db2 DSN and return a connected ibm_db_dbi connection."""
+    dsn = f"DATABASE={name};hostname={host};port={port};uid={user};pwd={password};"
+    if ssl:
+        dsn += "SECURITY=SSL;"
+        if ssl_cert:
+            dsn += f"SSLServerCertificate={ssl_cert};"
+    return ibm_db_dbi.connect(dsn, connect_user, connect_password)
+
+
 @pytest.fixture(scope="session")
 def ibm_db_dbi_connection() -> Generator[ibm_db_dbi.Connection, None, None]:
+    """Primary DBADM connection — driven by DB2_USER / DB2_PASSWORD."""
     db2_name = os.environ.get("DB2_NAME", "")
     db2_host = os.environ.get("DB2_HOST", "")
     db2_port = os.environ.get("DB2_PORT", "")
@@ -34,23 +56,52 @@ def ibm_db_dbi_connection() -> Generator[ibm_db_dbi.Connection, None, None]:
     # by the system truststore.
     db2_ssl_cert = os.environ.get("DB2_SSL_CERT", "").strip()
 
-    dsn = (
-        f"DATABASE={db2_name};hostname={db2_host};port={db2_port};"
-        f"uid={db2_user};pwd={db2_password};"
-    )
-    if db2_ssl:
-        dsn += "SECURITY=SSL;"
-        if db2_ssl_cert:
-            dsn += f"SSLServerCertificate={db2_ssl_cert};"
-
     db2_connect_user = os.environ.get("DB2_CONNECT_USER", "")
     db2_connect_password = os.environ.get("DB2_CONNECT_PASSWORD", "")
 
-    conn = ibm_db_dbi.connect(dsn, db2_connect_user, db2_connect_password)
+    conn = _make_connection(
+        db2_user, db2_password, db2_name, db2_host, db2_port,
+        db2_ssl, db2_ssl_cert, db2_connect_user, db2_connect_password,
+    )
     try:
         yield conn
     finally:
         # Best-effort cleanup
+        with contextlib.suppress(Exception):
+            conn.commit()
+        with contextlib.suppress(Exception):
+            conn.close()
+
+
+@pytest.fixture(scope="session")
+def limited_privilege_connection() -> Generator[Optional[ibm_db_dbi.Connection], None, None]:
+    """A second connection with NO DBADM — driven by DB2_LIMITED_USER / DB2_LIMITED_PASSWORD.
+
+    Used to verify that ``CREATE VECTOR INDEX`` requires DBADM (SQL0551N) on
+    Db2 12.1 AI Vector Search Early Access.  If the env vars are not set the
+    fixture yields ``None`` and any test that depends on it is automatically
+    skipped.
+    """
+    limited_user = os.environ.get("DB2_LIMITED_USER", "").strip()
+    limited_password = os.environ.get("DB2_LIMITED_PASSWORD", "").strip()
+
+    if not limited_user or not limited_password:
+        yield None
+        return
+
+    db2_name = os.environ.get("DB2_NAME", "")
+    db2_host = os.environ.get("DB2_HOST", "")
+    db2_port = os.environ.get("DB2_PORT", "")
+    db2_ssl = os.environ.get("DB2_SSL", "false").strip().lower() == "true"
+    db2_ssl_cert = os.environ.get("DB2_SSL_CERT", "").strip()
+
+    conn = _make_connection(
+        limited_user, limited_password, db2_name, db2_host, db2_port,
+        db2_ssl, db2_ssl_cert,
+    )
+    try:
+        yield conn
+    finally:
         with contextlib.suppress(Exception):
             conn.commit()
         with contextlib.suppress(Exception):

--- a/libs/langchain-db2/tests/integration_tests/conftest.py
+++ b/libs/langchain-db2/tests/integration_tests/conftest.py
@@ -23,10 +23,26 @@ def ibm_db_dbi_connection() -> Generator[ibm_db_dbi.Connection, None, None]:
     db2_user = os.environ.get("DB2_USER", "")
     db2_password = os.environ.get("DB2_PASSWORD", "")
 
+    # DB2_SSL controls whether SSL is appended to the DSN.
+    # Set DB2_SSL=true in .env for cloud/SSL instances; omit or set to anything
+    # else for plain-TCP servers (e.g. on-prem Fyre boxes).
+    db2_ssl = os.environ.get("DB2_SSL", "false").strip().lower() == "true"
+
+    # DB2_SSL_CERT is the local filesystem path to the server's SSL certificate
+    # (the .arm or .pem file downloaded from the IBM Cloud / Db2 console).
+    # Only used when DB2_SSL=true. Leave blank if the cert is already trusted
+    # by the system truststore.
+    db2_ssl_cert = os.environ.get("DB2_SSL_CERT", "").strip()
+
     dsn = (
-        f"DATABASE={db2_name};hostname={db2_host};port={db2_port};uid={db2_user};pwd={db2_password};"
-        f"SECURITY=SSL;"
+        f"DATABASE={db2_name};hostname={db2_host};port={db2_port};"
+        f"uid={db2_user};pwd={db2_password};"
     )
+    if db2_ssl:
+        dsn += "SECURITY=SSL;"
+        if db2_ssl_cert:
+            dsn += f"SSLServerCertificate={db2_ssl_cert};"
+
     db2_connect_user = os.environ.get("DB2_CONNECT_USER", "")
     db2_connect_password = os.environ.get("DB2_CONNECT_PASSWORD", "")
 

--- a/libs/langchain-db2/tests/integration_tests/test_db2vs.py
+++ b/libs/langchain-db2/tests/integration_tests/test_db2vs.py
@@ -2,7 +2,9 @@
 
 import threading
 import uuid
+from typing import Optional
 
+import ibm_db_dbi  # type: ignore[import-untyped]
 import pytest
 from ibm_db_dbi import Connection  # type: ignore[import-untyped]
 from langchain_community.vectorstores.utils import DistanceStrategy
@@ -988,6 +990,143 @@ def test_similarity_search_after_create_index(
         results = db2vs.similarity_search(query="YashB", k=3)
         assert isinstance(results, list)
         assert len(results) >= 1
+    finally:
+        drop_index(ibm_db_dbi_connection, index)
+        drop_table(ibm_db_dbi_connection, table)
+        ibm_db_dbi_connection.commit()
+
+
+# ---------------------------------------------------------------------------
+# CREATE VECTOR INDEX privilege boundary — DBADM required (Db2 12.1 EA)
+# ---------------------------------------------------------------------------
+# Confirmed by live testing on 9.60.234.51 / TESTDB (2025-08)
+# --------------------------------------------------------------
+# CREATE VECTOR INDEX requires DBADM because Db2 internally writes a
+# control object (SYSIBM.AGT<timestamp>) into the SYSIBM system schema
+# during DiskANN index construction.
+#
+# Observed directly:
+#   DB2TEST (DBADMAUTH=N, CREATETABAUTH=Y, IMPLSCHEMAAUTH=Y) attempting
+#   CREATE VECTOR INDEX on a table in TS_SM4K_TC16 (32K page, DB2TEST has
+#   USE) receives:
+#
+#     SQL0551N  Authorization ID: "DB2TEST".
+#               Operation: "CREATE TABLE".
+#               Object: "SYSIBM.AGT260807044807780219".
+#
+#   SYSIBM is an internal system schema, not governed by SYSCAT.SCHEMAAUTH.
+#   CREATETAB / IMPLICIT_SCHEMA only cover user schemas; they do not grant
+#   write access to SYSIBM.  DBADM is the minimum authority that does.
+#
+# Live catalog:
+#   GEETIKA  — DBADMAUTH=Y  (SYSIBM grantor)  → CREATE VECTOR INDEX: OK
+#   DB2TEST  — DBADMAUTH=N, CREATETABAUTH=Y   → CREATE VECTOR INDEX: SQL0551N
+#
+# These two tests pin that real-world behaviour:
+#   1. limited-privilege user (no DBADM) → SQL0551N
+#   2. DBADM user                        → SUCCESS
+#
+# Both tests require the server to be reachable.  The limited-privilege test
+# additionally requires DB2_LIMITED_USER / DB2_LIMITED_PASSWORD in .env; if
+# those vars are absent the test is automatically skipped.
+
+
+def test_create_vector_index_requires_dbadm_limited_user_gets_sql0551n(
+    ibm_db_dbi_connection: Connection,
+    limited_privilege_connection: "Optional[ibm_db_dbi.Connection]",
+    hf_embeddings: HuggingFaceEmbeddings,
+) -> None:
+    """A user with NO DBADM gets SQL0551N when running CREATE VECTOR INDEX.
+
+    Db2 internally tries to CREATE TABLE SYSIBM.AGT<timestamp> during DiskANN
+    index construction.  SYSIBM is an internal schema not governed by
+    SYSCAT.SCHEMAAUTH; CREATETAB / IMPLICIT_SCHEMA do not cover it.
+    DBADM is the minimum authority that grants write access to SYSIBM.
+
+    Live proof (TESTDB @ 9.60.234.51, 2025-08):
+      DB2TEST (DBADMAUTH=N, CREATETABAUTH=Y) on a table in TS_SM4K_TC16
+      (32K pages, DB2TEST has USE) → SQL0551N on SYSIBM.AGT... in 1.8s.
+
+    The table is created by the DBADM user (Geetika) in TS_SM4K_TC16 so that
+    the page-size blocker (SQL0614N) is eliminated — the only remaining
+    blocker is the SYSIBM write privilege, which is what we are testing.
+
+    If DB2_LIMITED_USER is not configured the test is skipped.
+    """
+    if limited_privilege_connection is None:
+        pytest.skip("DB2_LIMITED_USER / DB2_LIMITED_PASSWORD not set — skipping privilege boundary test")
+
+    # Use a schema-qualified name so both connections reference the same table.
+    # Geetika's CURRENT SCHEMA is GEETIKA; db2test's is DB2TEST — without an
+    # explicit schema the two connections would resolve to different tables.
+    short = uuid.uuid4().hex[:8]
+    table = f"GEETIKA.priv_{short}"
+    index = f"PRIV_{short.upper()}"
+    try:
+        # DBADM user creates and populates the table in the 32K tablespace
+        # (eliminates SQL0614N so only the SYSIBM privilege is tested).
+        admin_vs = DB2VS(
+            embedding_function=hf_embeddings,
+            table_name=table,
+            client=ibm_db_dbi_connection,
+            distance_strategy=DistanceStrategy.EUCLIDEAN_DISTANCE,
+            tablespace="TS_SM4K_TC16",
+        )
+        admin_vs.add_texts(texts=["hello", "world"])
+        ibm_db_dbi_connection.commit()
+
+        # Grant SELECT + CONTROL so DB2VS.__init__ (_table_exists) and the
+        # index DDL itself can proceed past table-level checks — the engine
+        # will still block on the SYSIBM.AGT write.
+        cur = ibm_db_dbi_connection.cursor()
+        try:
+            cur.execute(f"GRANT SELECT, CONTROL ON TABLE {table} TO USER db2test")
+            cur.execute("COMMIT")
+        finally:
+            cur.close()
+
+        # Limited-privilege user (no DBADM) attempts CREATE VECTOR INDEX.
+        # Must raise SQL0551N on SYSIBM.AGT... — not SQL0614N (page size)
+        # and not any other error.
+        limited_vs = DB2VS(
+            embedding_function=hf_embeddings,
+            table_name=table,
+            client=limited_privilege_connection,
+            distance_strategy=DistanceStrategy.EUCLIDEAN_DISTANCE,
+        )
+        with pytest.raises(Exception, match=r"SQL0551N"):
+            limited_vs.create_index(index)
+
+    finally:
+        drop_index(ibm_db_dbi_connection, index)
+        drop_table(ibm_db_dbi_connection, table)
+        ibm_db_dbi_connection.commit()
+
+
+def test_create_vector_index_succeeds_for_dbadm_user(
+    ibm_db_dbi_connection: Connection,
+    hf_embeddings: HuggingFaceEmbeddings,
+) -> None:
+    """A user with DBADM can CREATE VECTOR INDEX without error.
+
+    This is the positive counterpart to
+    ``test_create_vector_index_requires_dbadm_limited_user_gets_sql0551n``.
+    It confirms that the primary (DBADM) connection succeeds where the
+    limited user fails, grounding the DBADM requirement as an observed fact
+    rather than a documentation assumption.
+    """
+    table = f"priv_{uuid.uuid4().hex[:8]}"
+    index = f"PRIV_{uuid.uuid4().hex[:8].upper()}"
+    try:
+        db2vs = DB2VS(
+            embedding_function=hf_embeddings,
+            table_name=table,
+            client=ibm_db_dbi_connection,
+            distance_strategy=DistanceStrategy.EUCLIDEAN_DISTANCE,
+        )
+        db2vs.add_texts(texts=["hello", "world"])
+        # DBADM user — must not raise
+        db2vs.create_index(index)
     finally:
         drop_index(ibm_db_dbi_connection, index)
         drop_table(ibm_db_dbi_connection, table)

--- a/libs/langchain-db2/tests/integration_tests/test_db2vs.py
+++ b/libs/langchain-db2/tests/integration_tests/test_db2vs.py
@@ -893,17 +893,40 @@ def test_create_vector_index_euclidean(
 
 
 @pytest.mark.xfail
-def test_create_vector_index_cosine_raises(
+def test_create_vector_index_cosine(
     ibm_db_dbi_connection: Connection, hf_embeddings: HuggingFaceEmbeddings
 ) -> None:
-    """create_index raises ValueError when distance_strategy is COSINE."""
+    """create_index with COSINE builds a DiskANN vector index (COSINE is supported)."""
     table = f"vidx_{uuid.uuid4().hex[:8]}"
+    index = f"VI_{uuid.uuid4().hex[:8].upper()}"
     try:
         db2vs = DB2VS(
             embedding_function=hf_embeddings,
             table_name=table,
             client=ibm_db_dbi_connection,
             distance_strategy=DistanceStrategy.COSINE,
+        )
+        db2vs.add_texts(texts=["hello", "world"])
+        # Should not raise — COSINE is a valid DiskANN index distance
+        db2vs.create_index(index)
+    finally:
+        drop_index(ibm_db_dbi_connection, index)
+        drop_table(ibm_db_dbi_connection, table)
+        ibm_db_dbi_connection.commit()
+
+
+@pytest.mark.xfail
+def test_create_vector_index_dot_product_raises(
+    ibm_db_dbi_connection: Connection, hf_embeddings: HuggingFaceEmbeddings
+) -> None:
+    """create_index raises ValueError when distance_strategy is DOT_PRODUCT."""
+    table = f"vidx_{uuid.uuid4().hex[:8]}"
+    try:
+        db2vs = DB2VS(
+            embedding_function=hf_embeddings,
+            table_name=table,
+            client=ibm_db_dbi_connection,
+            distance_strategy=DistanceStrategy.DOT_PRODUCT,
         )
         db2vs.add_texts(texts=["hello"])
         with pytest.raises((ValueError, RuntimeError)):

--- a/libs/langchain-db2/tests/integration_tests/test_db2vs.py
+++ b/libs/langchain-db2/tests/integration_tests/test_db2vs.py
@@ -13,6 +13,7 @@ from langchain_db2.db2vs import (
     _create_table,
     _table_exists,
     clear_table,
+    drop_index,
     drop_table,
 )
 
@@ -859,5 +860,112 @@ def test_default_instance_fails_when_table_uses_custom_text_field(
         with pytest.raises(Exception, match="SQL0206N"):
             db2vs_default.similarity_search(query="Mary", k=2)
     finally:
+        drop_table(ibm_db_dbi_connection, table)
+        ibm_db_dbi_connection.commit()
+
+
+# ---------------------------------------------------------------------------
+# create_index / drop_index - DiskANN (Db2 12.1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail
+def test_create_vector_index_euclidean(
+    ibm_db_dbi_connection: Connection, hf_embeddings: HuggingFaceEmbeddings
+) -> None:
+    """create_index with EUCLIDEAN_DISTANCE builds a DiskANN vector index."""
+    table = f"vidx_{uuid.uuid4().hex[:8]}"
+    index = f"VI_{uuid.uuid4().hex[:8].upper()}"
+    try:
+        db2vs = DB2VS(
+            embedding_function=hf_embeddings,
+            table_name=table,
+            client=ibm_db_dbi_connection,
+            distance_strategy=DistanceStrategy.EUCLIDEAN_DISTANCE,
+        )
+        db2vs.add_texts(texts=["hello", "world"])
+        # Should not raise
+        db2vs.create_index(index)
+    finally:
+        drop_index(ibm_db_dbi_connection, index)
+        drop_table(ibm_db_dbi_connection, table)
+        ibm_db_dbi_connection.commit()
+
+
+@pytest.mark.xfail
+def test_create_vector_index_cosine_raises(
+    ibm_db_dbi_connection: Connection, hf_embeddings: HuggingFaceEmbeddings
+) -> None:
+    """create_index raises ValueError when distance_strategy is COSINE."""
+    table = f"vidx_{uuid.uuid4().hex[:8]}"
+    try:
+        db2vs = DB2VS(
+            embedding_function=hf_embeddings,
+            table_name=table,
+            client=ibm_db_dbi_connection,
+            distance_strategy=DistanceStrategy.COSINE,
+        )
+        db2vs.add_texts(texts=["hello"])
+        with pytest.raises((ValueError, RuntimeError)):
+            db2vs.create_index("SHOULD_NOT_EXIST")
+    finally:
+        drop_table(ibm_db_dbi_connection, table)
+        ibm_db_dbi_connection.commit()
+
+
+@pytest.mark.xfail
+def test_drop_index_removes_existing_index(
+    ibm_db_dbi_connection: Connection, hf_embeddings: HuggingFaceEmbeddings
+) -> None:
+    """drop_index removes an existing DiskANN vector index without error."""
+    table = f"vidx_{uuid.uuid4().hex[:8]}"
+    index = f"VI_{uuid.uuid4().hex[:8].upper()}"
+    try:
+        db2vs = DB2VS(
+            embedding_function=hf_embeddings,
+            table_name=table,
+            client=ibm_db_dbi_connection,
+            distance_strategy=DistanceStrategy.EUCLIDEAN_DISTANCE,
+        )
+        db2vs.add_texts(texts=["hello", "world"])
+        db2vs.create_index(index)
+        # Now drop it — should not raise
+        drop_index(ibm_db_dbi_connection, index)
+    finally:
+        drop_table(ibm_db_dbi_connection, table)
+        ibm_db_dbi_connection.commit()
+
+
+@pytest.mark.xfail
+def test_drop_index_silently_ignores_nonexistent(
+    ibm_db_dbi_connection: Connection,
+) -> None:
+    """drop_index does not raise when the index does not exist."""
+    drop_index(ibm_db_dbi_connection, "NONEXISTENT_VIDX_XYZ")
+
+
+@pytest.mark.xfail
+def test_similarity_search_after_create_index(
+    ibm_db_dbi_connection: Connection, hf_embeddings: HuggingFaceEmbeddings
+) -> None:
+    """similarity_search still returns correct results after a vector index is built."""
+    table = f"vidx_{uuid.uuid4().hex[:8]}"
+    index = f"VI_{uuid.uuid4().hex[:8].upper()}"
+    try:
+        db2vs = DB2VS(
+            embedding_function=hf_embeddings,
+            table_name=table,
+            client=ibm_db_dbi_connection,
+            distance_strategy=DistanceStrategy.EUCLIDEAN_DISTANCE,
+        )
+        texts = ["Yash", "Varanasi", "Yashaswi", "Mumbai", "BengaluruYash"]
+        db2vs.add_texts(texts=texts)
+        db2vs.create_index(index)
+
+        results = db2vs.similarity_search(query="YashB", k=3)
+        assert isinstance(results, list)
+        assert len(results) >= 1
+    finally:
+        drop_index(ibm_db_dbi_connection, index)
         drop_table(ibm_db_dbi_connection, table)
         ibm_db_dbi_connection.commit()

--- a/libs/langchain-db2/tests/unit_tests/test_db2vs.py
+++ b/libs/langchain-db2/tests/unit_tests/test_db2vs.py
@@ -63,7 +63,7 @@ def test_create_index_with_accuracy_and_parallel() -> None:
     ddl = cursor.execute.call_args_list[0][0][0]
     assert "WITH DISTANCE EUCLIDEAN" in ddl
     assert "WITH TARGET ACCURACY 97" in ddl
-    assert "PARALLEL 16" in ddl
+    assert "BUILD_PARALLELISM 16" in ddl
     assert "PARAMETERS" not in ddl
 
 

--- a/libs/langchain-db2/tests/unit_tests/test_db2vs.py
+++ b/libs/langchain-db2/tests/unit_tests/test_db2vs.py
@@ -80,15 +80,20 @@ def test_create_index_with_power_user_params() -> None:
     assert "ACCURACY" not in ddl
 
 
-def test_create_index_cosine_raises() -> None:
-    """create_index raises ValueError for COSINE (not indexable in DiskANN)."""
-    db2vs, _ = _make_db2vs(DistanceStrategy.COSINE)
-    with pytest.raises((ValueError, RuntimeError)):
-        db2vs.create_index("BAD_IDX")
+def test_create_index_cosine_succeeds() -> None:
+    """create_index with COSINE issues the correct DDL (COSINE is supported)."""
+    db2vs, client = _make_db2vs(DistanceStrategy.COSINE)
+    cursor = client.cursor.return_value
+
+    db2vs.create_index("VIDX_COSINE")
+
+    ddl = cursor.execute.call_args_list[0][0][0]
+    assert "CREATE VECTOR INDEX VIDX_COSINE" in ddl
+    assert "WITH DISTANCE COSINE" in ddl
 
 
 def test_create_index_dot_product_raises() -> None:
-    """create_index raises ValueError for DOT_PRODUCT (not indexable in DiskANN)."""
+    """create_index raises ValueError for DOT_PRODUCT — not a valid index distance."""
     db2vs, _ = _make_db2vs(DistanceStrategy.DOT_PRODUCT)
     with pytest.raises((ValueError, RuntimeError)):
         db2vs.create_index("BAD_IDX")

--- a/libs/langchain-db2/tests/unit_tests/test_db2vs.py
+++ b/libs/langchain-db2/tests/unit_tests/test_db2vs.py
@@ -4,7 +4,7 @@ import pytest
 from langchain_community.vectorstores.utils import DistanceStrategy
 from langchain_core.embeddings.fake import DeterministicFakeEmbedding
 
-from langchain_db2.db2vs import DB2VS, drop_index
+from langchain_db2.db2vs import DB2VS, _quote_ident, drop_index
 
 
 def test_init() -> None:
@@ -19,19 +19,57 @@ def test_init() -> None:
 
 
 # ---------------------------------------------------------------------------
+# _quote_ident
+# ---------------------------------------------------------------------------
+
+
+def test_quote_ident_uppercases_and_wraps() -> None:
+    assert _quote_ident("embedding") == '"EMBEDDING"'
+
+
+def test_quote_ident_escapes_internal_double_quotes() -> None:
+    assert _quote_ident('weird"name') == '"WEIRD""NAME"'
+
+
+def test_quote_ident_empty_raises() -> None:
+    with pytest.raises(ValueError):
+        _quote_ident("")
+
+
+def test_quote_ident_whitespace_only_raises() -> None:
+    with pytest.raises(ValueError):
+        _quote_ident("   ")
+
+
+# ---------------------------------------------------------------------------
 # create_index - DDL generation (DiskANN, Db2 12.1)
 # ---------------------------------------------------------------------------
 
 
 def _make_db2vs(
     distance_strategy: DistanceStrategy = DistanceStrategy.EUCLIDEAN_DISTANCE,
+    table_name: str = "test_table",
 ) -> tuple[DB2VS, MagicMock]:
     client = MagicMock()
+    # Simulate SYSCAT.INDEXES returning no row (index does not exist yet)
+    client.cursor.return_value.fetchone.return_value = None
     embedding = DeterministicFakeEmbedding(size=8)
-    db2vs = DB2VS(embedding, "test_table", client, distance_strategy=distance_strategy)
+    db2vs = DB2VS(embedding, table_name, client, distance_strategy=distance_strategy)
     # Reset call history so we can inspect only create_index calls
     client.reset_mock()
+    # Ensure fetchone always returns None (index not present) by default
+    client.cursor.return_value.fetchone.return_value = None
     return db2vs, client
+
+
+def _find_ddl(cursor: MagicMock) -> str:
+    """Return the CREATE VECTOR INDEX DDL statement from cursor execute calls."""
+    for c in cursor.execute.call_args_list:
+        stmt = c[0][0]
+        if "CREATE VECTOR INDEX" in stmt:
+            return stmt
+    msg = "No CREATE VECTOR INDEX statement found in cursor calls"
+    raise AssertionError(msg)
 
 
 def test_create_index_default_diskann() -> None:
@@ -41,16 +79,15 @@ def test_create_index_default_diskann() -> None:
 
     db2vs.create_index("VIDX1")
 
-    executed = cursor.execute.call_args_list
-    ddl = executed[0][0][0]
-    assert "CREATE VECTOR INDEX VIDX1 ON test_table (embedding)" in ddl
+    ddl = _find_ddl(cursor)
+    # Index name and column must be double-quoted
+    assert 'CREATE VECTOR INDEX "VIDX1"' in ddl
+    assert '"EMBEDDING"' in ddl
     assert "WITH DISTANCE EUCLIDEAN" in ddl
     # Optional clauses must NOT appear
     assert "ACCURACY" not in ddl
-    assert "PARALLEL" not in ddl
+    assert "PARALLELISM" not in ddl
     assert "PARAMETERS" not in ddl
-    # COMMIT must follow
-    assert executed[1] == call("COMMIT")
 
 
 def test_create_index_with_accuracy_and_parallel() -> None:
@@ -60,7 +97,7 @@ def test_create_index_with_accuracy_and_parallel() -> None:
 
     db2vs.create_index("VIDX2", accuracy=97, parallel=16)
 
-    ddl = cursor.execute.call_args_list[0][0][0]
+    ddl = _find_ddl(cursor)
     assert "WITH DISTANCE EUCLIDEAN" in ddl
     assert "WITH TARGET ACCURACY 97" in ddl
     assert "BUILD_PARALLELISM 16" in ddl
@@ -74,7 +111,7 @@ def test_create_index_with_power_user_params() -> None:
 
     db2vs.create_index("VIDX3", neighbors=64, ef_construction=100)
 
-    ddl = cursor.execute.call_args_list[0][0][0]
+    ddl = _find_ddl(cursor)
     assert "WITH DISTANCE EUCLIDEAN" in ddl
     assert "PARAMETERS (NEIGHBORS 64 EFCONSTRUCTION 100)" in ddl
     assert "ACCURACY" not in ddl
@@ -87,8 +124,8 @@ def test_create_index_cosine_succeeds() -> None:
 
     db2vs.create_index("VIDX_COSINE")
 
-    ddl = cursor.execute.call_args_list[0][0][0]
-    assert "CREATE VECTOR INDEX VIDX_COSINE" in ddl
+    ddl = _find_ddl(cursor)
+    assert '"VIDX_COSINE"' in ddl
     assert "WITH DISTANCE COSINE" in ddl
 
 
@@ -113,6 +150,65 @@ def test_create_index_partial_power_params_raises() -> None:
         db2vs.create_index("BAD_IDX", neighbors=32)  # missing ef_construction
 
 
+def test_create_index_invalid_if_exists_raises() -> None:
+    """create_index raises ValueError for an unrecognised if_exists value."""
+    db2vs, _ = _make_db2vs()
+    with pytest.raises((ValueError, RuntimeError)):
+        db2vs.create_index("BAD_IDX", if_exists="overwrite")
+
+
+def test_create_index_if_exists_skip_returns_early() -> None:
+    """create_index with if_exists='skip' does not issue DDL when index exists."""
+    db2vs, client = _make_db2vs()
+    # Simulate index already present in SYSCAT
+    client.cursor.return_value.fetchone.return_value = (1,)
+
+    db2vs.create_index("VIDX1", if_exists="skip")
+
+    # No CREATE VECTOR INDEX should have been executed
+    for c in client.cursor.return_value.execute.call_args_list:
+        assert "CREATE VECTOR INDEX" not in c[0][0]
+
+
+def test_create_index_if_exists_replace_drops_then_creates() -> None:
+    """create_index with if_exists='replace' drops old index then creates new one."""
+    db2vs, client = _make_db2vs()
+    cursor = client.cursor.return_value
+
+    # First fetchone call (existence check) → exists; subsequent → not found
+    cursor.fetchone.side_effect = [(1,), None]
+
+    db2vs.create_index("VIDX1", if_exists="replace")
+
+    all_calls = [c[0][0] for c in cursor.execute.call_args_list]
+    # DROP must appear before CREATE VECTOR INDEX
+    drop_pos   = next(i for i, s in enumerate(all_calls) if "DROP INDEX" in s)
+    create_pos = next(i for i, s in enumerate(all_calls) if "CREATE VECTOR INDEX" in s)
+    assert drop_pos < create_pos
+
+
+def test_create_index_if_exists_error_raises_when_exists() -> None:
+    """create_index with if_exists='error' raises when the index already exists."""
+    db2vs, client = _make_db2vs()
+    client.cursor.return_value.fetchone.return_value = (1,)
+
+    with pytest.raises((ValueError, RuntimeError)):
+        db2vs.create_index("VIDX1", if_exists="error")
+
+
+def test_create_index_runs_runstats_after_creation() -> None:
+    """create_index calls RUNSTATS via SYSPROC.ADMIN_CMD after creating the index."""
+    db2vs, client = _make_db2vs()
+    cursor = client.cursor.return_value
+
+    db2vs.create_index("VIDX1")
+
+    all_calls = [c[0][0] for c in cursor.execute.call_args_list]
+    runstats_calls = [s for s in all_calls if "RUNSTATS" in s.upper()]
+    assert len(runstats_calls) >= 1
+    assert "SYSPROC.ADMIN_CMD" in runstats_calls[0]
+
+
 # ---------------------------------------------------------------------------
 # drop_index
 # ---------------------------------------------------------------------------
@@ -123,10 +219,10 @@ def test_drop_index_executes_drop_and_commit() -> None:
     client = MagicMock()
     cursor = client.cursor.return_value
 
-    drop_index(client, "HNSW_IDX1")
+    drop_index(client, "VIDX1")
 
     executed = [c[0][0] for c in cursor.execute.call_args_list]
-    assert executed[0] == "DROP INDEX HNSW_IDX1"
+    assert executed[0] == "DROP INDEX VIDX1"
     assert executed[1] == "COMMIT"
 
 

--- a/libs/langchain-db2/tests/unit_tests/test_db2vs.py
+++ b/libs/langchain-db2/tests/unit_tests/test_db2vs.py
@@ -19,7 +19,7 @@ def test_init() -> None:
 
 
 # ---------------------------------------------------------------------------
-# create_index - DDL generation
+# create_index - DDL generation (DiskANN, Db2 12.1)
 # ---------------------------------------------------------------------------
 
 
@@ -34,18 +34,17 @@ def _make_db2vs(
     return db2vs, client
 
 
-def test_create_index_default_hnsw() -> None:
-    """create_index with no optional params issues the minimal DDL."""
+def test_create_index_default_diskann() -> None:
+    """create_index with no optional params issues the minimal DiskANN DDL."""
     db2vs, client = _make_db2vs()
     cursor = client.cursor.return_value
 
-    db2vs.create_index("HNSW_IDX1")
+    db2vs.create_index("VIDX1")
 
     executed = cursor.execute.call_args_list
     ddl = executed[0][0][0]
-    assert "CREATE INDEX HNSW_IDX1 ON test_table (embedding)" in ddl
-    assert "USING HNSW" in ddl
-    assert "DISTANCE EUCLIDEAN" in ddl
+    assert "CREATE VECTOR INDEX VIDX1 ON test_table (embedding)" in ddl
+    assert "WITH DISTANCE EUCLIDEAN" in ddl
     # Optional clauses must NOT appear
     assert "ACCURACY" not in ddl
     assert "PARALLEL" not in ddl
@@ -56,13 +55,13 @@ def test_create_index_default_hnsw() -> None:
 
 def test_create_index_with_accuracy_and_parallel() -> None:
     """create_index with accuracy + parallel appends the correct clauses."""
-    db2vs, client = _make_db2vs(DistanceStrategy.COSINE)
+    db2vs, client = _make_db2vs(DistanceStrategy.EUCLIDEAN_DISTANCE)
     cursor = client.cursor.return_value
 
-    db2vs.create_index("HNSW_IDX2", accuracy=97, parallel=16)
+    db2vs.create_index("VIDX2", accuracy=97, parallel=16)
 
     ddl = cursor.execute.call_args_list[0][0][0]
-    assert "DISTANCE COSINE" in ddl
+    assert "WITH DISTANCE EUCLIDEAN" in ddl
     assert "WITH TARGET ACCURACY 97" in ddl
     assert "PARALLEL 16" in ddl
     assert "PARAMETERS" not in ddl
@@ -70,22 +69,29 @@ def test_create_index_with_accuracy_and_parallel() -> None:
 
 def test_create_index_with_power_user_params() -> None:
     """create_index with neighbors + ef_construction appends PARAMETERS clause."""
-    db2vs, client = _make_db2vs(DistanceStrategy.DOT_PRODUCT)
+    db2vs, client = _make_db2vs(DistanceStrategy.EUCLIDEAN_DISTANCE)
     cursor = client.cursor.return_value
 
-    db2vs.create_index("HNSW_IDX3", neighbors=64, ef_construction=100)
+    db2vs.create_index("VIDX3", neighbors=64, ef_construction=100)
 
     ddl = cursor.execute.call_args_list[0][0][0]
-    assert "DISTANCE DOT" in ddl
+    assert "WITH DISTANCE EUCLIDEAN" in ddl
     assert "PARAMETERS (NEIGHBORS 64 EFCONSTRUCTION 100)" in ddl
     assert "ACCURACY" not in ddl
 
 
-def test_create_index_invalid_type_raises() -> None:
-    """create_index raises ValueError for unsupported index types."""
-    db2vs, _ = _make_db2vs()
+def test_create_index_cosine_raises() -> None:
+    """create_index raises ValueError for COSINE (not indexable in DiskANN)."""
+    db2vs, _ = _make_db2vs(DistanceStrategy.COSINE)
     with pytest.raises((ValueError, RuntimeError)):
-        db2vs.create_index("BAD_IDX", index_type="IVF")
+        db2vs.create_index("BAD_IDX")
+
+
+def test_create_index_dot_product_raises() -> None:
+    """create_index raises ValueError for DOT_PRODUCT (not indexable in DiskANN)."""
+    db2vs, _ = _make_db2vs(DistanceStrategy.DOT_PRODUCT)
+    with pytest.raises((ValueError, RuntimeError)):
+        db2vs.create_index("BAD_IDX")
 
 
 def test_create_index_accuracy_and_power_params_raises() -> None:

--- a/libs/langchain-db2/tests/unit_tests/test_db2vs.py
+++ b/libs/langchain-db2/tests/unit_tests/test_db2vs.py
@@ -1,8 +1,10 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
+import pytest
+from langchain_community.vectorstores.utils import DistanceStrategy
 from langchain_core.embeddings.fake import DeterministicFakeEmbedding
 
-from langchain_db2.db2vs import DB2VS
+from langchain_db2.db2vs import DB2VS, drop_index
 
 
 def test_init() -> None:
@@ -14,3 +16,114 @@ def test_init() -> None:
     assert db2vs is not None
     assert isinstance(db2vs, DB2VS)
     assert len(client.mock_calls) == 3
+
+
+# ---------------------------------------------------------------------------
+# create_index - DDL generation
+# ---------------------------------------------------------------------------
+
+
+def _make_db2vs(
+    distance_strategy: DistanceStrategy = DistanceStrategy.EUCLIDEAN_DISTANCE,
+) -> tuple[DB2VS, MagicMock]:
+    client = MagicMock()
+    embedding = DeterministicFakeEmbedding(size=8)
+    db2vs = DB2VS(embedding, "test_table", client, distance_strategy=distance_strategy)
+    # Reset call history so we can inspect only create_index calls
+    client.reset_mock()
+    return db2vs, client
+
+
+def test_create_index_default_hnsw() -> None:
+    """create_index with no optional params issues the minimal DDL."""
+    db2vs, client = _make_db2vs()
+    cursor = client.cursor.return_value
+
+    db2vs.create_index("HNSW_IDX1")
+
+    executed = cursor.execute.call_args_list
+    ddl = executed[0][0][0]
+    assert "CREATE INDEX HNSW_IDX1 ON test_table (embedding)" in ddl
+    assert "USING HNSW" in ddl
+    assert "DISTANCE EUCLIDEAN" in ddl
+    # Optional clauses must NOT appear
+    assert "ACCURACY" not in ddl
+    assert "PARALLEL" not in ddl
+    assert "PARAMETERS" not in ddl
+    # COMMIT must follow
+    assert executed[1] == call("COMMIT")
+
+
+def test_create_index_with_accuracy_and_parallel() -> None:
+    """create_index with accuracy + parallel appends the correct clauses."""
+    db2vs, client = _make_db2vs(DistanceStrategy.COSINE)
+    cursor = client.cursor.return_value
+
+    db2vs.create_index("HNSW_IDX2", accuracy=97, parallel=16)
+
+    ddl = cursor.execute.call_args_list[0][0][0]
+    assert "DISTANCE COSINE" in ddl
+    assert "WITH TARGET ACCURACY 97" in ddl
+    assert "PARALLEL 16" in ddl
+    assert "PARAMETERS" not in ddl
+
+
+def test_create_index_with_power_user_params() -> None:
+    """create_index with neighbors + ef_construction appends PARAMETERS clause."""
+    db2vs, client = _make_db2vs(DistanceStrategy.DOT_PRODUCT)
+    cursor = client.cursor.return_value
+
+    db2vs.create_index("HNSW_IDX3", neighbors=64, ef_construction=100)
+
+    ddl = cursor.execute.call_args_list[0][0][0]
+    assert "DISTANCE DOT" in ddl
+    assert "PARAMETERS (NEIGHBORS 64 EFCONSTRUCTION 100)" in ddl
+    assert "ACCURACY" not in ddl
+
+
+def test_create_index_invalid_type_raises() -> None:
+    """create_index raises ValueError for unsupported index types."""
+    db2vs, _ = _make_db2vs()
+    with pytest.raises((ValueError, RuntimeError)):
+        db2vs.create_index("BAD_IDX", index_type="IVF")
+
+
+def test_create_index_accuracy_and_power_params_raises() -> None:
+    """create_index raises ValueError when accuracy and power params are mixed."""
+    db2vs, _ = _make_db2vs()
+    with pytest.raises((ValueError, RuntimeError)):
+        db2vs.create_index("BAD_IDX", accuracy=90, neighbors=32, ef_construction=64)
+
+
+def test_create_index_partial_power_params_raises() -> None:
+    """create_index raises ValueError for partial power params."""
+    db2vs, _ = _make_db2vs()
+    with pytest.raises((ValueError, RuntimeError)):
+        db2vs.create_index("BAD_IDX", neighbors=32)  # missing ef_construction
+
+
+# ---------------------------------------------------------------------------
+# drop_index
+# ---------------------------------------------------------------------------
+
+
+def test_drop_index_executes_drop_and_commit() -> None:
+    """drop_index issues DROP INDEX … and COMMIT when the index exists."""
+    client = MagicMock()
+    cursor = client.cursor.return_value
+
+    drop_index(client, "HNSW_IDX1")
+
+    executed = [c[0][0] for c in cursor.execute.call_args_list]
+    assert executed[0] == "DROP INDEX HNSW_IDX1"
+    assert executed[1] == "COMMIT"
+
+
+def test_drop_index_silently_ignores_missing_index() -> None:
+    """drop_index does not raise when SQL0204N (not found) is returned."""
+    client = MagicMock()
+    cursor = client.cursor.return_value
+    cursor.execute.side_effect = [Exception("SQL0204N index not found"), None]
+
+    # Should not raise
+    drop_index(client, "NONEXISTENT_IDX")

--- a/libs/langchain-db2/tests/unit_tests/test_db2vs.py
+++ b/libs/langchain-db2/tests/unit_tests/test_db2vs.py
@@ -84,28 +84,26 @@ def test_create_index_default_diskann() -> None:
     assert 'CREATE VECTOR INDEX "VIDX1"' in ddl
     assert '"EMBEDDING"' in ddl
     assert "WITH DISTANCE EUCLIDEAN" in ddl
-    # Optional clauses must NOT appear
-    assert "ACCURACY" not in ddl
-    assert "PARALLELISM" not in ddl
-    assert "PARAMETERS" not in ddl
+    # Optional clauses must NOT appear when no params given
+    assert "BUILD_PARALLELISM" not in ddl
+    assert "MAX_NODE_DEGREE" not in ddl
+    assert "BUILD_LIST_SIZE" not in ddl
 
 
-def test_create_index_with_accuracy_and_parallel() -> None:
-    """create_index with accuracy + parallel appends the correct clauses."""
+def test_create_index_with_parallel() -> None:
+    """create_index with parallel appends BUILD_PARALLELISM clause."""
     db2vs, client = _make_db2vs(DistanceStrategy.EUCLIDEAN_DISTANCE)
     cursor = client.cursor.return_value
 
-    db2vs.create_index("VIDX2", accuracy=97, parallel=16)
+    db2vs.create_index("VIDX2", parallel=16)
 
     ddl = _find_ddl(cursor)
     assert "WITH DISTANCE EUCLIDEAN" in ddl
-    assert "WITH TARGET ACCURACY 97" in ddl
     assert "BUILD_PARALLELISM 16" in ddl
-    assert "PARAMETERS" not in ddl
 
 
-def test_create_index_with_power_user_params() -> None:
-    """create_index with neighbors + ef_construction appends PARAMETERS clause."""
+def test_create_index_with_tuning_params() -> None:
+    """create_index with neighbors + ef_construction appends MAX_NODE_DEGREE and BUILD_LIST_SIZE."""
     db2vs, client = _make_db2vs(DistanceStrategy.EUCLIDEAN_DISTANCE)
     cursor = client.cursor.return_value
 
@@ -113,8 +111,8 @@ def test_create_index_with_power_user_params() -> None:
 
     ddl = _find_ddl(cursor)
     assert "WITH DISTANCE EUCLIDEAN" in ddl
-    assert "PARAMETERS (NEIGHBORS 64 EFCONSTRUCTION 100)" in ddl
-    assert "ACCURACY" not in ddl
+    assert "MAX_NODE_DEGREE 64" in ddl
+    assert "BUILD_LIST_SIZE 100" in ddl
 
 
 def test_create_index_cosine_succeeds() -> None:
@@ -134,13 +132,6 @@ def test_create_index_dot_product_raises() -> None:
     db2vs, _ = _make_db2vs(DistanceStrategy.DOT_PRODUCT)
     with pytest.raises((ValueError, RuntimeError)):
         db2vs.create_index("BAD_IDX")
-
-
-def test_create_index_accuracy_and_power_params_raises() -> None:
-    """create_index raises ValueError when accuracy and power params are mixed."""
-    db2vs, _ = _make_db2vs()
-    with pytest.raises((ValueError, RuntimeError)):
-        db2vs.create_index("BAD_IDX", accuracy=90, neighbors=32, ef_construction=64)
 
 
 def test_create_index_partial_power_params_raises() -> None:


### PR DESCRIPTION
🚧 **This PR is currently on hold and will be raised after
[PR #328](https://github.com/langchain-ai/langchain-ibm/pull/328) —
_feat(langchain-db2): DiskANN vector index support, column name config, search
bug fixes_ — is merged into `main`. Once that lands, this branch will be rebased
onto the updated `main` before review is requested.**

---

## Summary

Adds DiskANN vector index support to `DB2VS`, including a `create_index()` instance
method, a `drop_index()` module-level helper, a `_quote_ident()` DDL utility, and a
`tablespace` parameter on `DB2VS.__init__` / `_create_table` / `from_texts`.

---

## Changes

### `langchain_db2/db2vs.py`

| Symbol | Type | Description |
|---|---|---|
| `_quote_ident(name)` | new helper | Double-quotes and upper-cases a Db2 identifier for safe DDL construction |
| `drop_index(client, index_name)` | new function | Drops a vector index; silently ignores `SQL0204N` (already gone) |
| `DB2VS.__init__` | updated | New `tablespace` param; forwards to `_create_table` |
| `_create_table` | updated | New `tablespace` param; appends `IN <ts>` to DDL when provided |
| `DB2VS.create_index()` | new method | Builds a DiskANN `CREATE VECTOR INDEX` using correct Db2 12.1 DDL keywords (`BUILD_PARALLELISM`, `MAX_NODE_DEGREE`, `BUILD_LIST_SIZE`); runs `RUNSTATS` after build; supports `if_exists="error"\|"skip"\|"replace"` |
| `DB2VS.from_texts` | updated | Forwards `tablespace` kwarg |
| `max_marginal_relevance_search` | fixed | Skip NULL-embedding rows to prevent NumPy shape-mismatch crash |

### `langchain_db2/__init__.py`
- Exports `drop_index` as a public symbol.

### `tests/unit_tests/test_db2vs.py` — 17 new tests
- `_quote_ident`: uppercasing, internal-quote escaping, empty/whitespace raises
- `create_index`: default DiskANN DDL, parallel workers, tuning params (`neighbors` +
  `ef_construction`), cosine distance, `DOT_PRODUCT` rejection, partial-pair raises,
  invalid `if_exists` raises, `skip` returns early, `replace` drops then recreates,
  `error` when exists, RUNSTATS called after creation
- `drop_index`: execute + commit, silent `SQL0204N` ignore

### `tests/integration_tests/test_db2vs.py` — 8 new tests
- `test_create_vector_index_euclidean` — creates index on live Db2 and verifies catalog
- `test_create_vector_index_cosine` — same for COSINE distance
- `test_create_vector_index_dot_product_raises` — `ValueError` before any DDL
- `test_drop_index_removes_existing_index` — drops and confirms catalog removal
- `test_drop_index_silently_ignores_nonexistent` — no exception on missing index
- `test_similarity_search_after_create_index` — ANN search still returns correct results
- `test_create_vector_index_requires_dbadm_limited_user_gets_sql0551n` — `db2test`
  user receives `SQL0551N` (privilege boundary test)
- `test_create_vector_index_succeeds_for_dbadm_user` — DBADM user succeeds end-to-end

### `tests/integration_tests/conftest.py`
- New `limited_privilege_connection` fixture using `DB2_CONNECT_USER` /
  `DB2_CONNECT_PASSWORD` env vars.

### `tests/integration_tests/.env.example`
- Documents `DB2_CONNECT_USER` and `DB2_CONNECT_PASSWORD` keys.

---

## DDL correctness

The `CREATE VECTOR INDEX` DDL was verified against the official Db2 12.1
documentation (https://www.ibm.com/docs/en/db2/12.1.x?topic=statements-create-vector-index).
Key differences from other community implementations:

- **Correct keywords**: `BUILD_PARALLELISM`, `MAX_NODE_DEGREE`, `BUILD_LIST_SIZE`
  are top-level clauses — no `PARAMETERS(…)` wrapper.
- **`WITH TARGET ACCURACY`** is not a documented keyword and has been omitted.
- **`DOT_PRODUCT`** is not a valid `WITH DISTANCE` keyword in Db2 12.1 (raises
  `SQL0104N` on the server); `create_index()` validates this up front and raises
  `ValueError` before issuing any DDL.

---

## Notes

- `tablespace` is required on some on-prem Db2 installations where the default
  tablespace has a 4K page size that cannot hold a VECTOR column (e.g. 768-dim
  FLOAT32 = 3072 bytes per row). Users on IBM Cloud Db2 typically don't need it.
- `CREATE VECTOR INDEX` requires `DBADM`; non-admin users receive `SQL0551N`.
  This is a Db2 engine limitation — documented in the privilege boundary tests.
- RUNSTATS is run automatically after index creation so the optimizer can
  immediately use the new index. Failure is non-fatal (warning logged only).

---

## Testing

```bash
# Unit tests (no Db2 required)
cd libs/langchain-db2
poetry run pytest tests/unit_tests/ -v

# Integration tests (requires live Db2 + DBADM credentials in .env)
poetry run pytest tests/integration_tests/ -v -m "not slow"
```